### PR TITLE
Make scraper independent of GitHub connection

### DIFF
--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -5,8 +5,16 @@ ES_USER = 'user'
 ES_PASSWORD = 'password'
 
 # Scraper configuration
-GITHUB_APP_ID = 0
-GITHUB_APP_KEY = '<path_to_keyfile>'
+CONNECTIONS = {
+    # This name must go in hand with the provider in the tenant sources file
+    '<name>': {
+        'provider': 'github',
+        'url': 'https://github.com',
+        'app_id': 0,
+        'app_key': '<path_to_keyfile>',
+    }
+}
+
 GITHUB_WEBHOOK_SECRET = '<secret>'
 # NOTE: Use only one of the following, not both
 TENANT_SOURCES_REPO = '<orga>/<repo>'

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -5,13 +5,24 @@ ES_USER = 'user'
 ES_PASSWORD = 'password'
 
 # Scraper configuration
+# NOTE: The connection names must go in hand with the ones used in the tenant
+# configuration
 CONNECTIONS = {
-    # This name must go in hand with the provider in the tenant sources file
+    # GitHub example
     '<name>': {
         'provider': 'github',
         'url': 'https://github.com',
         'app_id': 0,
         'app_key': '<path_to_keyfile>',
+    },
+    # Gerrit example
+    '<name>': {
+        'provider': 'gerrit',
+        'url': '<git_remote_url>',
+        # Only necessary if different from the git_remote_url
+        'web_url': '<gerrit_url>',
+        'user': '<username>',
+        'password': '<password',
     }
 }
 

--- a/tests/scraper/connections/test_github.py
+++ b/tests/scraper/connections/test_github.py
@@ -23,15 +23,15 @@ GITHUB_URL = "https://github.example.com"
 GITHUB_API_URL = "{}/api/v3".format(GITHUB_URL)
 
 GITHUB_CON_CONFIG = {
-    "GITHUB_APP_ID": 1,
-    "GITHUB_APP_KEY": "tests/testdata/app_key_file",
-    "GITHUB_URL": GITHUB_URL,
+    "app_id": 1,
+    "app_key": "tests/testdata/app_key_file",
+    "url": GITHUB_URL,
 }
 
 
 def test_get_app_auth_headers():
     # Initialize GitHubConnection
-    gh_con = GitHubConnection(GITHUB_CON_CONFIG)
+    gh_con = GitHubConnection(**GITHUB_CON_CONFIG)
     gh_con._authenticate()
 
     result = gh_con._get_app_auth_headers()
@@ -47,7 +47,7 @@ def test_get_installation_key(
 ):
 
     # Initialize GitHubConnection
-    gh_con = GitHubConnection(GITHUB_CON_CONFIG)
+    gh_con = GitHubConnection(**GITHUB_CON_CONFIG)
     gh_con._authenticate()
 
     with requests_mock.Mocker() as m:

--- a/tests/scraper/test_integration.py
+++ b/tests/scraper/test_integration.py
@@ -220,9 +220,18 @@ def test_scrape_not_github():
     tenant_parser.parse()
 
     expected_repo_map = {
-        "repo1": {"provider": "gerrit", "tenants": {"jobs": ["bar"], "roles": ["bar"]}},
-        "repo2": {"provider": "gerrit", "tenants": {"jobs": ["bar"], "roles": ["bar"]}},
-        "repo3": {"provider": "gerrit", "tenants": {"jobs": ["bar"], "roles": ["bar"]}},
+        "repo1": {
+            "connection_name": "gerrit",
+            "tenants": {"jobs": ["bar"], "roles": ["bar"]},
+        },
+        "repo2": {
+            "connection_name": "gerrit",
+            "tenants": {"jobs": ["bar"], "roles": ["bar"]},
+        },
+        "repo3": {
+            "connection_name": "gerrit",
+            "tenants": {"jobs": ["bar"], "roles": ["bar"]},
+        },
     }
 
     tenant_list = tenant_parser.tenants

--- a/tests/testdata/test.bar.yaml
+++ b/tests/testdata/test.bar.yaml
@@ -2,7 +2,7 @@
     exclude-unprotected-branches: true
     name: bar
     source:
-      ascent:
+      gerrit:
         untrusted-projects:
           - repo1
           - repo2

--- a/zubbi/default_settings.py
+++ b/zubbi/default_settings.py
@@ -14,4 +14,3 @@
 
 SEARCH_BATCH_SIZE = 9
 SEARCH_BATCH_LIMIT = 30
-GITHUB_URL = "https://github.com"

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -63,6 +63,7 @@ class ZuulTenant(ZubbiDoc):
 
 class GitRepo(ZubbiDoc):
     repo_name = Text()
+    provider = Text()
 
     class Index:
         name = "git-repos"

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from zubbi.utils import urljoin
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class GerritConnection:
@@ -27,8 +32,8 @@ class GerritConnection:
         # TODO If we want to support ssh and https, we should add a protocol parameter
 
     def init(self):
+        LOGGER.info("Initializing Gerrit connection to %s", self.base_url)
         # Currently we don't need to do anything here
-        pass
 
     def get_remote_url(self, repository_name):
         # TODO (felix) Find a better way to rebuild the url with auth values

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -21,9 +21,19 @@ LOGGER = logging.getLogger(__name__)
 
 
 class GerritConnection:
-    def __init__(self, url, user, password, web_url=None):
+    # TODO (felix): Should we ensure that only the user that started zubbi has access rights
+    # to this workspace directory?
+    def __init__(
+        self, url, user, password, workspace="/tmp/zubbi_working_dir", web_url=None
+    ):
         self.base_url = url
         self.gitweb_url = urljoin(web_url or url, "gitweb")
+
+        # TODO (felix): Not sure if the connection is the right scope for this variable,
+        # but it's the simplest way to configure it - and one could argue, that the
+        # workspace directory is depending on the connection entry in the settings file
+        # (different connection -> different workspace)
+        self.workspace_dir = workspace
 
         # TODO Support password via envvar (like in zapfel)
         self.user = user

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -16,7 +16,27 @@ from zubbi.utils import urljoin
 
 
 class GerritConnection:
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, url, user, password, web_url=None):
+        self.base_url = url
+        self.gitweb_url = urljoin(web_url or url, "gitweb")
 
-        self.gitweb_url = urljoin(self.config["GERRIT_URL"], "gitweb")
+        # TODO Support password via envvar (like in zapfel)
+        self.user = user
+        self.password = password
+
+        # TODO If we want to support ssh and https, we should add a protocol parameter
+
+    def init(self):
+        # Currently we don't need to do anything here
+        pass
+
+    def get_remote_url(self, repository_name):
+        # TODO (felix) Find a better way to rebuild the url with auth values
+        scheme, _, url = self.base_url.partition("://")
+        auth_base_url = "{}://{}:{}@{}".format(scheme, self.user, self.password, url)
+        remote_url = urljoin(auth_base_url, repository_name)
+        return remote_url
+
+    @property
+    def name(self):
+        return "gerrit"

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -38,5 +38,5 @@ class GerritConnection:
         return remote_url
 
     @property
-    def name(self):
+    def provider(self):
         return "gerrit"

--- a/zubbi/scraper/connections/github.py
+++ b/zubbi/scraper/connections/github.py
@@ -186,6 +186,10 @@ class GitHubConnection:
     def repos(self):
         return self.installation_map.keys()
 
+    @property
+    def name(self):
+        return "github"
+
     def get_repos_for_installation(self, install_id):
         return [
             k

--- a/zubbi/scraper/connections/github.py
+++ b/zubbi/scraper/connections/github.py
@@ -33,31 +33,33 @@ class GitHubConnection:
         self.api_url = urljoin(url, "api/v3")
         self.graphql_url = urljoin(url, "api/graphql")
 
-        self.app_id = None
-        self.app_key = None
+        self._app_id = app_id
+        self._app_key = app_key
 
         self.installation_map = {}
         self.installation_token_cache = {}
 
+    def init(self):
         # Initialize the connection
-        self._authenticate(app_id, app_key)
+        self._authenticate()
         self._prime_install_map()
 
-    def _authenticate(self, app_id, app_key_file):
+    def _authenticate(self):
+        LOGGER.debug("Authenticating against GitHub")
         try:
-            with open(app_key_file, "r") as f:
+            with open(self._app_key, "r") as f:
                 app_key = f.read()
         except IOError:
-            LOGGER.error("Failed to open app key file: %s", app_key_file)
+            LOGGER.error("Failed to open app key file: %s", self._app_key)
 
-        if not app_id and app_key:
+        if not self._app_id and app_key:
             LOGGER.error(
                 "You must provide an app_id and an app_key to use "
                 "installation based authentication"
             )
             return
 
-        self.app_id = app_id
+        self.app_id = self._app_id
         self.app_key = app_key
 
     def _get_app_auth_headers(self):

--- a/zubbi/scraper/connections/github.py
+++ b/zubbi/scraper/connections/github.py
@@ -40,7 +40,7 @@ class GitHubConnection:
         self.installation_token_cache = {}
 
     def init(self):
-        # Initialize the connection
+        LOGGER.info("Initializing GitHub connection to %s", self.base_url)
         self._authenticate()
         self._prime_install_map()
 

--- a/zubbi/scraper/connections/github.py
+++ b/zubbi/scraper/connections/github.py
@@ -16,6 +16,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
+import github3
 import jwt
 import requests
 
@@ -164,6 +165,20 @@ class GitHubConnection:
 
                 # Check if we need to do further page calls
                 url = response.links.get("next", {}).get("url")
+
+    def create_github_client(self, project):
+        """Create a github3 client per repo/installation."""
+        token = self._get_installation_key(project=project)
+        if not token:
+            LOGGER.warning(
+                "Could not find an authentication token for '%s'. Do you "
+                "have access to this repository?",
+                project,
+            )
+            return
+        gh = github3.GitHubEnterprise(self.base_url)
+        gh.login(token=token)
+        return gh
 
     @property
     def repos(self):

--- a/zubbi/scraper/connections/github.py
+++ b/zubbi/scraper/connections/github.py
@@ -187,7 +187,7 @@ class GitHubConnection:
         return self.installation_map.keys()
 
     @property
-    def name(self):
+    def provider(self):
         return "github"
 
     def get_repos_for_installation(self, install_id):

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -394,7 +394,7 @@ def _scrape_repo_map(
         # Update tenant sources
 
         # First, store the tenants in Elasticsearch
-        LOGGER.debug(
+        LOGGER.info(
             "Updating %d tenant definitions in Elasticsearch", len(tenant_list)
         )
         ZuulTenant.bulk_save(tenant_list)
@@ -430,7 +430,7 @@ def _scrape_repo_map(
             scrape_repo(repo, tenants, scrape_time)
 
         # Store the information for all repos we just scraped in Elasticsearch
-        LOGGER.debug("Updating %d repo definitions in Elasticsearch", len(es_repos))
+        LOGGER.info("Updating %d repo definitions in Elasticsearch", len(es_repos))
         GitRepo.bulk_save(es_repos)
     else:
         LOGGER.info("Deleting the following repositories: %s", repo_list)
@@ -463,10 +463,10 @@ def scrape_repo(repo, tenants, scrape_time):
 
     jobs, roles = RepoParser(repo, tenants, job_files, role_files, scrape_time).parse()
 
-    LOGGER.debug("Updating %d job definitions in Elasticsearch", len(jobs))
+    LOGGER.info("Updating %d job definitions in Elasticsearch", len(jobs))
     ZuulJob.bulk_save(jobs)
 
-    LOGGER.debug("Updating %d role definitions in Elasticsearch", len(roles))
+    LOGGER.info("Updating %d role definitions in Elasticsearch", len(roles))
     AnsibleRole.bulk_save(roles)
 
 

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -271,6 +271,7 @@ def init_connections(config):
         # connections['github'] = gh_con
         con_class = CONNECTIONS.get(con_data.pop("provider"))
         con = con_class(**con_data)
+        con.init()
         connections[con_name] = con
     return connections
 

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -95,7 +95,7 @@ def _initialize_tenant_parser(tenant_sources_repo, tenant_sources_file, connecti
 
 
 def _initialize_repo_cache():
-    """Initializes the repository cache used for scraping.
+    """Initialize the repository cache used for scraping.
 
     Retrieves a list of repositories with their provider and last scraping time
     from Elasticsearch.
@@ -394,9 +394,7 @@ def _scrape_repo_map(
         # Update tenant sources
 
         # First, store the tenants in Elasticsearch
-        LOGGER.info(
-            "Updating %d tenant definitions in Elasticsearch", len(tenant_list)
-        )
+        LOGGER.info("Updating %d tenant definitions in Elasticsearch", len(tenant_list))
         ZuulTenant.bulk_save(tenant_list)
 
         LOGGER.info("Scraping the following repositories: %s", repo_list)

--- a/zubbi/scraper/repos/gerrit.py
+++ b/zubbi/scraper/repos/gerrit.py
@@ -14,17 +14,22 @@
 
 from zubbi.scraper.repos.git import GitRepository
 
+# TODO (felix): Make this configurable somehow (at least via envvars)
+WORKSPACE_DIR = 'tmp'
+
 
 class GerritRepository(GitRepository):
     # NOTE (fschmidt): As the Gerrit API does not support everything we need,
     # we let the GitRepository do all the checkouts and directory listings
     # and use the gerrit API only for building the URLs which are shown in zubbi.
 
-    def __init__(self, repo_name, workspace_dir, remote_url, gerrit_con):
-        super().__init__(repo_name, workspace_dir, remote_url)
+    def __init__(self, repo_name, gerrit_con):
+        # Build the remote url based on the gerrit connection parameters
+        remote_url = gerrit_con.get_remote_url(repo_name)
         self.gerrit_con = gerrit_con
+        super().__init__(repo_name, WORKSPACE_DIR, remote_url)
 
-    def get_url_for_file(self, file_path, highlight_start=None, highlight_end=None):
+    def url_for_file(self, file_path, highlight_start=None, highlight_end=None):
         file_url = "{}?p={}.git;a=blob;f={}".format(
             self.gerrit_con.gitweb_url, self.repo_name, file_path
         )
@@ -36,7 +41,7 @@ class GerritRepository(GitRepository):
 
         return file_url
 
-    def get_url_for_directory(self, directory_path):
+    def url_for_directory(self, directory_path):
         url = "{}?p={}.git;a=tree;f={}".format(
             self.gerrit_con.gitweb_url, self.repo_name, directory_path
         )

--- a/zubbi/scraper/repos/gerrit.py
+++ b/zubbi/scraper/repos/gerrit.py
@@ -14,9 +14,6 @@
 
 from zubbi.scraper.repos.git import GitRepository
 
-# TODO (felix): Make this configurable somehow (at least via envvars)
-WORKSPACE_DIR = 'tmp'
-
 
 class GerritRepository(GitRepository):
     # NOTE (fschmidt): As the Gerrit API does not support everything we need,
@@ -27,7 +24,8 @@ class GerritRepository(GitRepository):
         # Build the remote url based on the gerrit connection parameters
         remote_url = gerrit_con.get_remote_url(repo_name)
         self.gerrit_con = gerrit_con
-        super().__init__(repo_name, WORKSPACE_DIR, remote_url)
+        # Initialize the plain git repository via the GitRepository base class
+        super().__init__(repo_name, gerrit_con.workspace_dir, remote_url)
 
     def url_for_file(self, file_path, highlight_start=None, highlight_end=None):
         file_url = "{}?p={}.git;a=blob;f={}".format(

--- a/zubbi/scraper/repos/github.py
+++ b/zubbi/scraper/repos/github.py
@@ -48,9 +48,8 @@ query($owner:String!, $repo:String!, $path:String!) {
 
 
 class GitHubRepository(Repository):
-    def __init__(self, repo_name, gh, gh_con=None):
+    def __init__(self, repo_name, gh_con):
         self.repo_name = repo_name
-        self.gh = gh
         self.gh_con = gh_con
         self._repo = self._get_repo_object()
 
@@ -138,7 +137,9 @@ class GitHubRepository(Repository):
 
     def _get_repo_object(self):
         owner, repo_name = self.repo_name.split("/")
-        repo = self.gh.repository(owner=owner, repository=repo_name)
+        repo = self.gh_con.create_github_client(self.repo_name).repository(
+            owner=owner, repository=repo_name
+        )
         return repo
 
     def url_for_file(self, file_path, highlight_start=None, highlight_end=None):

--- a/zubbi/scraper/tenant_parser.py
+++ b/zubbi/scraper/tenant_parser.py
@@ -53,20 +53,21 @@ class TenantParser:
             tenant_name = tenant_src["tenant"]["name"]
 
             # Iterate over all repositories specified in this tenant (per provider)
-            for provider, source in sources.items():
+            for connection_name, source in sources.items():
                 # project_type is config- or untrusted-project
                 for project_type, projects in source.items():
                     for project in projects:
-                        self._update_repo_map(project, provider, tenant_name)
+                        self._update_repo_map(project, connection_name, tenant_name)
 
             self.tenants.append(tenant_name)
 
-    def _update_repo_map(self, project, provider, tenant):
+    def _update_repo_map(self, project, connection_name, tenant):
         project_name, exclude = self._extract_project(project)
 
         # Map the current tenant to the current repository
         repo_tenant_entry = self.repo_map.setdefault(
-            project_name, {"tenants": {"jobs": [], "roles": []}, "provider": provider}
+            project_name,
+            {"tenants": {"jobs": [], "roles": []}, "connection_name": connection_name},
         )
 
         # Update repo_tenant mapping

--- a/zubbi/views.py
+++ b/zubbi/views.py
@@ -307,7 +307,7 @@ class WebhookView(ZubbiMethodView):
             json_abort(401, "Request signature does not match calculated signature.")
 
     def check_event(self, headers):
-        # For now, we are only interessted in the following events:
+        # For now, we are only interested in the following events:
         # - installation {created, deleted}
         # - installation_repositories {added, removed}
         # - push


### PR DESCRIPTION
Although the connections were created dynamically, most scraper parts were
relying on a connection named "github" (as this was the only one we had so far).
This change removes this assumption and searches for the right connection and
repository provider based on the tenant sources and the configured connections
in the settings.cfg file.