### PR TITLE
Fix: Ignore files in roles dir and empty role directories

### DIFF
--- a/zubbi/scraper/scraper.py
+++ b/zubbi/scraper/scraper.py
@@ -92,6 +92,9 @@ class Scraper:
                 try:
                     last_changed = self.repo.last_changed(role_content.path)
                     existing_files = self.repo.list_directory(role_content.path)
+                    # Skip empty directories or files
+                    if not existing_files:
+                        continue
                     readme_file = self.find_matching_file(README_FILES, existing_files)
                     changelog_file = self.find_matching_file(
                         CHANGELOG_FILES, existing_files


### PR DESCRIPTION
After changing the scraper/repository API, non-directory roles are not excluded any longer, as plain git has no knowledge about directories, but only files. This change restores the old behaviour to ignore those cases.