### PR TITLE
Make ZMQ optional

### DIFF
--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -42,7 +42,7 @@ TENANT_SOURCES_FILE = 'tenant-config.yaml'
 
 ZMQ_PUB_SOCKET_ADDRESS = 'tcp://*:5556'
 ZMQ_SUB_SOCKET_ADDRESS = 'tcp://localhost:5556'
-# Timeout in milliseconds (5 min)
-ZMQ_SUB_TIMEOUT = 300000  # default
+# Timeout in seconds (5 min)
+ZMQ_SUB_TIMEOUT = 300  # default
 # Interval after which a repo will be scraped in any case (in hours)
 FORCE_SCRAPE_INTERVAL = 24  # default

--- a/zubbi/default_settings.py
+++ b/zubbi/default_settings.py
@@ -17,7 +17,7 @@ SEARCH_BATCH_LIMIT = 30
 
 
 # Scraper defaults
-# Timeout in milliseconds (5 min)
-ZMQ_SUB_TIMEOUT = 300000
+# Timeout in seconds (5 min)
+ZMQ_SUB_TIMEOUT = 300
 # Interval after which a repo will be scraped in any case (in hours)
 FORCE_SCRAPE_INTERVAL = 24

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -236,10 +236,10 @@ def scrape(ctx, full, repo):
         while True:
             if socket is None:
                 LOGGER.debug(
-                    "No ZMQ socket configured. Just going to wait for 5 minutes."
+                    "No ZMQ socket configured. Just going to wait for %d seconds.",
+                    timeout,
                 )
-                # Timeout is in milliseconds, but sleep uses seconds
-                time.sleep(timeout / 1000)
+                time.sleep(timeout)
             else:
                 # Check for incoming messages on ZMQ
                 LOGGER.debug("Checking for incoming ZMQ messages")
@@ -270,7 +270,8 @@ def create_zmq_socket(socket_addr, timeout):
         socket = context.socket(zmq.SUB)
         socket.connect(socket_addr)
         socket.setsockopt_string(zmq.SUBSCRIBE, "")
-        socket.setsockopt(zmq.RCVTIMEO, timeout)
+        # Timeout is in seconds, but ZMQ uses milliseconds
+        socket.setsockopt(zmq.RCVTIMEO, timeout * 1000)
     return socket
 
 

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -234,6 +234,11 @@ def scrape(ctx, full, repo):
         socket = create_zmq_socket(socket_addr, timeout)
 
         while True:
+            # Check if a periodic run is necessary
+            LOGGER.debug("Checking for outdated repos")
+            scrape_outdated(config, connections, tenant_parser, repo_cache)
+
+            # Listen to ZMQ messages (if configured) or wait
             if socket is None:
                 LOGGER.debug(
                     "No ZMQ socket configured. Just going to wait for %d seconds.",
@@ -257,10 +262,6 @@ def scrape(ctx, full, repo):
                     # If no message was received until the timeout, ZMQ throws
                     # zmq.error.Again: Resource temporarily unavailable
                     LOGGER.debug("Did not receive any ZMQ message")
-
-            # Check if a periodic run is necessary
-            LOGGER.debug("Checking for outdated repos")
-            scrape_outdated(config, connections, tenant_parser, repo_cache)
 
 
 def create_zmq_socket(socket_addr, timeout):


### PR DESCRIPTION
When using the scraper in periodic mode, we were relying on the ZMQ connection
to be configured. Although, there might be cases, where somebody want to use
Zubbi without webhooks. Therefore, the ZMQ connection is now optional. If not
configured, Zubbi scraper will scrape outdated repositories in the specified
interval and just wait in between (instead of listening to ZMQ messages).