### PR TITLE
Catch broader exceptions in Sphinx build

### DIFF
--- a/zubbi/doc.py
+++ b/zubbi/doc.py
@@ -130,6 +130,10 @@ def render_file(file_dict):
             LOGGER.warning(
                 "Content of %s could not be converted to HTML: %s", filepath, exc
             )
+        except LookupError:
+            LOGGER.exception(
+                "Sphinx build failed. Most probably due to the usage of an invalid Sphinx directive or Zuul variable type."
+            )
     elif filepath.lower().endswith(".md"):
         LOGGER.debug("Rendering markdown description")
         doc = render_markdown(content)


### PR DESCRIPTION
If a wrong variable type is used within the zuul:rolevar directive,
the ZuulSphinx plugin raises a KeyError rather than a SphinxBuildError.
With this change we also catch those Exceptions to not make Zubbi the
zubbi scraper fail because of an invalid README file.