### PR TITLE
Create Dockerfile for zubbi and start the whole stack with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Application files
 instance/
-settings.cfg
+/settings.cfg
 .env
 
 # Binaries

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /opt
 
 RUN apk add --no-cache openssl-dev curl zeromq git python3
 
-COPY settings.cfg tenant-config.yaml ./
-
 # Packages needed to build the cffi python package which is needed by cryptography
 RUN apk add --no-cache --virtual .build-deps \
         libffi-dev \
@@ -18,6 +16,8 @@ RUN apk add --no-cache --virtual .build-deps \
     && pip3 install --no-cache zubbi \
     # Delete build dependencies
     && apk del .build-deps
+
+COPY settings.cfg tenant-config.yaml ./
 
 VOLUME /opt/instance
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.7
+
+WORKDIR /opt
+
+RUN apk add --no-cache openssl-dev curl zeromq git python3
+
+COPY settings.cfg tenant-config.yaml ./
+
+# Packages needed to build the cffi python package which is needed by cryptography
+RUN apk add --no-cache --virtual .build-deps \
+        libffi-dev \
+        build-base \
+        python3-dev \
+    && pip3 install --no-cache zubbi \
+    && apk del .build-deps
+
+VOLUME /opt/instance
+VOLUME /var/share/zubbi
+
+ENV ZUBBI_INSTANCE_PATH=/opt/instance
+ENV ZUBBI_SETTINGS=/opt/settings.cfg
+ENV FLASK_APP=zubbi
+# flask runs on port 5000 per default
+#EXPOSE 5000
+
+# NOTE (fschmidt): The --host option is necessary, to reach flask from outside
+# the docker container
+CMD ["python3", "-m", "flask", "run", "--host=0.0.0.0"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# NOTE: This Dockerfile should only be used for demonstration purposes and not
+# in a production system. Flask is running in development mode and listens on
+# all public IPs to make it reachable from outside the docker container.
 FROM alpine:3.7
 
 WORKDIR /opt
@@ -11,17 +14,19 @@ RUN apk add --no-cache --virtual .build-deps \
         libffi-dev \
         build-base \
         python3-dev \
+    # Install zubbi from PyPI
     && pip3 install --no-cache zubbi \
+    # Delete build dependencies
     && apk del .build-deps
 
 VOLUME /opt/instance
-VOLUME /var/share/zubbi
 
 ENV ZUBBI_INSTANCE_PATH=/opt/instance
 ENV ZUBBI_SETTINGS=/opt/settings.cfg
 ENV FLASK_APP=zubbi
+
 # flask runs on port 5000 per default
-#EXPOSE 5000
+EXPOSE 5000
 
 # NOTE (fschmidt): The --host option is necessary, to reach flask from outside
 # the docker container

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,7 +12,21 @@ services:
     networks:
       - esnet
 
-  zubbi:
+  zubbi-scraper:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - elasticsearch
+    networks:
+      - esnet
+    # Let the zubbi-scraper do an initial full scrape
+    command: zubbi-scraper scrape --full
+    # Starting zubbi-scraper will fail until Elasticsearch is up and running.
+    # But run it only once
+    restart: on-failure
+
+  zubbi-web:
     build:
       context: .
       dockerfile: Dockerfile
@@ -23,7 +37,7 @@ services:
       - elasticsearch
     networks:
       - esnet
-    # We need to "wait" until Elasticsearch is up and running
+    # Starting zubbi-web will fail until Elasticsearch is up and running
     restart: always
 
 volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,6 +12,20 @@ services:
     networks:
       - esnet
 
+  zubbi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      # flask runs on port 5000 per default
+      - 5000:5000
+    depends_on:
+      - elasticsearch
+    networks:
+      - esnet
+    # We need to "wait" until Elasticsearch is up and running
+    restart: always
+
 volumes:
   esdata:
     driver: local

--- a/docker/settings.cfg
+++ b/docker/settings.cfg
@@ -1,0 +1,10 @@
+ES_HOST = 'elasticsearch'
+ES_PORT = 9200
+TENANT_SOURCES_FILE = '/opt/tenant-config.yaml'
+
+CONNECTIONS = {
+    'openstack-gerrit': {
+        'provider': 'git',
+        'url': 'https://git.openstack.org',
+    },
+}

--- a/docker/tenant-config.yaml
+++ b/docker/tenant-config.yaml
@@ -1,0 +1,6 @@
+- tenant:
+    name: openstack
+    source:
+      openstack-gerrit:
+        untrusted-projects:
+          - openstack-infra/zuul-jobs


### PR DESCRIPTION
With this change, it's easy to get the whole stack up and running. The
docker-compose file will start all necessary services and scrapes the
openstack-infra/zuul-jobs once to get some initial data:

```
$ cd docker
$ docker-compose build
$ docker-compose up
```