### PR TITLE
Build Gerrit web URLs based on the "gitweb type" (cgit/gitweb)

### DIFF
--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -21,6 +21,9 @@ CONNECTIONS = {
         'url': '<git_remote_url>',
         # Only necessary if different from the git_remote_url
         'web_url': '<gerrit_url>',
+        # The web_type is necessary to build the correct URLs for Gerrit.
+        # Currently supported types are 'cgit' (default) and 'gitweb'.
+        'web_type': 'cgit|gitweb',
         # Optional, if authentication is required
         'user': '<username>',
         'password': '<password',

--- a/tests/scraper/connections/test_init.py
+++ b/tests/scraper/connections/test_init.py
@@ -18,7 +18,7 @@ from unittest import mock
 import pytest
 
 import zubbi
-from zubbi.scraper.connections.gerrit import GerritConnection
+from zubbi.scraper.connections.gerrit import CGitUrlBuilder, GerritConnection
 from zubbi.scraper.connections.git import GitConnection
 from zubbi.scraper.connections.github import GitHubConnection
 from zubbi.scraper.main import init_connections
@@ -50,14 +50,16 @@ def test_init_gerrit_con(patch_es):
         "password": "eggs",
         "workspace_dir": "/tmp/zubbi_working_dir",
         "base_url": "https://localhost/gerrit",
-        "gitweb_url": "https://localhost/gerrit-web/gitweb",
+        "gitweb_url": "https://localhost/gerrit-web",
+        "gitweb_type": "cgit",
     }
 
     connections = init_connections(config)
     gerrit_con = connections["gerrit_con"]
 
     assert isinstance(gerrit_con, GerritConnection)
-    assert gerrit_con.__dict__ == expected_con_data
+    assert isinstance(gerrit_con.web_url_builder, CGitUrlBuilder)
+    assert vars(gerrit_con) == expected_con_data
 
 
 def test_init_github_con(patch_es, mock_github_api_endpoints):

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -15,6 +15,7 @@
 import logging
 
 from zubbi.scraper.connections.git import GitConnection
+from zubbi.scraper.exceptions import ScraperConfigurationError
 from zubbi.utils import urljoin
 
 
@@ -92,6 +93,10 @@ class GerritConnection(GitConnection):
     def get_web_url_builder(self, web_type, web_url, url):
         web_url = web_url or url
         url_builder_class = self.WEB_URL_BUILDERS.get(web_type)
-        if url_builder_class is not None:
-            return url_builder_class(web_url)
-        LOGGER.error("Unsupported web_type: ''", web_type)
+        if url_builder_class is None:
+            raise ScraperConfigurationError(
+                "Could not initialize Gerrit connection due to an unsupported web_type '{}'".format(
+                    web_type
+                )
+            )
+        return url_builder_class(web_url)

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -30,7 +30,6 @@ class CGitUrlBuilder:
 
         if highlight_start is not None:
             file_url = "{}#n{}".format(file_url, highlight_start)
-
         # NOTE (felix): highlighting a range is not supported by cgit
 
         return file_url
@@ -49,7 +48,6 @@ class GitwebUrlBuilder:
 
         if highlight_start is not None:
             file_url = "{}#l{}".format(file_url, highlight_start)
-
         # NOTE (felix): highlighting a range is not supported by gitweb
 
         return file_url

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -21,15 +21,64 @@ from zubbi.utils import urljoin
 LOGGER = logging.getLogger(__name__)
 
 
+class CGitUrlBuilder:
+    def __init__(self, web_url):
+        self.web_url = web_url
+
+    def build_file_url(self, repo_name, file_path, highlight_start, highlight_end):
+        file_url = urljoin(self.web_url, repo_name, "tree", file_path)
+
+        if highlight_start is not None:
+            file_url = "{}#n{}".format(file_url, highlight_start)
+
+        # NOTE (felix): highlighting a range is not supported by cgit
+
+        return file_url
+
+    def build_directory_url(self, repo_name, directory_path):
+        directory_url = urljoin(self.web_url, repo_name, "tree", directory_path)
+        return directory_url
+
+
+class GitwebUrlBuilder:
+    def __init__(self, web_url):
+        self.web_url = web_url
+
+    def build_file_url(self, repo_name, file_path, highlight_start, highlight_end):
+        file_url = "{}?p={}.git;a=blob;f={}".format(self.web_url, repo_name, file_path)
+
+        if highlight_start is not None:
+            file_url = "{}#l{}".format(file_url, highlight_start)
+
+        # NOTE (felix): highlighting a range is not supported by gitweb
+
+        return file_url
+
+    def build_directory_url(self, repo_name, directory_path):
+        url = "{}?p={}.git;a=tree;f={}".format(self.web_url, repo_name, directory_path)
+        return url
+
+
 class GerritConnection(GitConnection):
+
+    WEB_URL_BUILDERS = {"cgit": CGitUrlBuilder, "gitweb": GitwebUrlBuilder}
+
     # TODO (felix): Should we ensure that only the user that started zubbi has access rights
     # to this workspace directory?
     def __init__(
-        self, url, user, password, workspace="/tmp/zubbi_working_dir", web_url=None
+        self,
+        url,
+        user,
+        password,
+        workspace="/tmp/zubbi_working_dir",
+        web_type="cgit",
+        web_url=None,
     ):
         super().__init__(url, user, password, workspace)
         self.base_url = url
-        self.gitweb_url = urljoin(web_url or url, "gitweb")
+        self.gitweb_type = web_type
+        self.gitweb_url = web_url or url
+        self.web_url_builder = self.get_web_url_builder(web_type, web_url, url)
 
         self.user = user
         self.password = password
@@ -41,3 +90,10 @@ class GerritConnection(GitConnection):
     @property
     def provider(self):
         return "gerrit"
+
+    def get_web_url_builder(self, web_type, web_url, url):
+        web_url = web_url or url
+        url_builder_class = self.WEB_URL_BUILDERS.get(web_type)
+        if url_builder_class is not None:
+            return url_builder_class(web_url)
+        LOGGER.error("Unsupported web_type: ''", web_type)

--- a/zubbi/scraper/repos/gerrit.py
+++ b/zubbi/scraper/repos/gerrit.py
@@ -26,19 +26,11 @@ class GerritRepository(GitRepository):
         super().__init__(repo_name, gerrit_con)
 
     def url_for_file(self, file_path, highlight_start=None, highlight_end=None):
-        file_url = "{}?p={}.git;a=blob;f={}".format(
-            self.gerrit_con.gitweb_url, self.repo_name, file_path
+        return self.gerrit_con.web_url_builder.build_file_url(
+            self.repo_name, file_path, highlight_start, highlight_end
         )
-
-        if highlight_start is not None:
-            file_url = "{}#l{}".format(file_url, highlight_start)
-
-        # NOTE (fschmidt): highlighting a range is not supported by gerrit/gitweb
-
-        return file_url
 
     def url_for_directory(self, directory_path):
-        url = "{}?p={}.git;a=tree;f={}".format(
-            self.gerrit_con.gitweb_url, self.repo_name, directory_path
+        return self.gerrit_con.web_url_builder.build_directory_url(
+            self.repo_name, directory_path
         )
-        return url

--- a/zubbi/templates/details.html
+++ b/zubbi/templates/details.html
@@ -24,9 +24,15 @@
   <div class="col-3">
     <div class="sidebar-section">
       <strong>Repository</strong><br>
-      <a href="{{ block.url }}" class="vertical-tab"><i class="fab fa-github"></i>
-      {{ block.repo }}
-      </a>
+      {% if block.url %}
+        <a href="{{ block.url }}" class="vertical-tab"><i class="fab fa-github"></i>
+          {{ block.repo }}
+        </a>
+      {% else %}
+        <span class="vertical-tab"><i class="fab fa-github"></i>
+            {{ block.repo }}
+        </span>
+      {% endif %}
     </div>
     <div class="sidebar-section">
       <strong>Platforms</strong>


### PR DESCRIPTION
Unfortunately, the Gerrit web URLs (used for browsing directories and 
showing files) are completely different and depending on the tool that is
used for the Gerrit "web endpoint". This change supports the usage of cgit
and gitweb as Gerrit web endpoint and builds the URLs accordingly.

I've discovered a third tool called "gitiles", which is not covered by this
change.