### PR TITLE
Fix listing of non-directories in GitHub

### DIFF
--- a/zubbi/scraper/repos/github.py
+++ b/zubbi/scraper/repos/github.py
@@ -78,6 +78,8 @@ class GitHubRepository(Repository):
             return remote_directory
         except github3.exceptions.NotFoundError:
             raise CheckoutError(directory_path, "Directory not found.")
+        except github3.exceptions.UnprocessableResponseBody:
+            raise CheckoutError(directory_path, "Path is not a directory")
 
     def last_changed(self, path):
         LOGGER.debug("Getting last changes for '%s'", path)


### PR DESCRIPTION
We are assuming that the roles/ directory contains only directories (as
every role must be a directory). When this is not the case and we are
tring to list a file, github3.py throws an UnprocessableResponseBody
error which is catched by this change.