### PR TITLE
Make Gerrit credentials optional and update zubbi-demo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## 1.0.0 - TBD
+## 1.1.0
+
+### New Features
+- Add support for `gitweb` and `cgit` as Gerrit web front-ends. Those are
+  necessary to build the correct URLs which are pointing to a job's or role's
+  definition file/directory in Gerrit.
+
+### Fixes
+- Make Gerrit credentials really optional
+
+## 1.0.0
 
 ### New Features
 - **Gerrit support:** Zubbi now supports scraping of Gerrit repositories. In

--- a/README.md
+++ b/README.md
@@ -335,9 +335,12 @@ CONNECTIONS = {
         'url': '<git_remote_url>',
         # Only necessary if different from the git_remote_url
         'web_url': '<gerrit_url>',
+        # The web_type is necessary to build the correct URLs for Gerrit.
+        # Currently supported types are 'cgit' (default) and 'gitweb'.
+        'web_type': 'cgit|gitweb',
         # Optional, if authentication is required
         'user': '<username>',
-        'password': '<password',
+        'password': '<password>',
     },
     ...
 }

--- a/docker/settings.cfg
+++ b/docker/settings.cfg
@@ -4,7 +4,8 @@ TENANT_SOURCES_FILE = '/opt/tenant-config.yaml'
 
 CONNECTIONS = {
     'openstack-gerrit': {
-        'provider': 'git',
+        'provider': 'gerrit',
         'url': 'https://git.openstack.org',
+        'web_url': 'https://git.openstack.org/cgit',
     },
 }

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -26,7 +26,7 @@ CONNECTIONS = {
         'web_type': 'cgit|gitweb',
         # Optional, if authentication is required
         'user': '<username>',
-        'password': '<password',
+        'password': '<password>',
     },
     # Git example
     '<name>': {

--- a/zubbi/scraper/connections/gerrit.py
+++ b/zubbi/scraper/connections/gerrit.py
@@ -67,8 +67,8 @@ class GerritConnection(GitConnection):
     def __init__(
         self,
         url,
-        user,
-        password,
+        user=None,
+        password=None,
         workspace="/tmp/zubbi_working_dir",
         web_type="cgit",
         web_url=None,
@@ -78,9 +78,6 @@ class GerritConnection(GitConnection):
         self.gitweb_type = web_type
         self.gitweb_url = web_url or url
         self.web_url_builder = self.get_web_url_builder(web_type, web_url, url)
-
-        self.user = user
-        self.password = password
 
     def init(self):
         LOGGER.info("Initializing Gerrit connection to %s", self.base_url)


### PR DESCRIPTION
1. So far, the credentials were optional in the underlying GitConnection,
   but had to be set in the GerritConnection. This change makes them now
   really optional.

2. This makes use of the newest changes (cgit implementation) to enable
   the Gerrit links on a block's details page.