### PR TITLE
Implement missing methods in Git repo class to retrieve update information for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.2.0 (TBD)
+
+### New Features
+- **Gerrit/Git:** Get last update information via commit history and blame info
+  for jobs and roles. So far, this was only available for GitHub repositories.
+- **UI:** Autofocus the search field on index page. You can now visit Zubbi and
+  directly start typing
+- **UI:** Show "last update" timestamps for jobs and roles in search results
+
 ## 1.1.0
 
 ### New Features

--- a/zubbi/scraper/repos/git.py
+++ b/zubbi/scraper/repos/git.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 from pathlib import Path
 
 from git import Repo
@@ -99,8 +100,13 @@ class GitRepository(Repository):
             raise CheckoutError(directory_path, e.stderr)
 
     def last_changed(self, path):
-        # TODO Implement...
-        pass
+        LOGGER.debug("Getting last changes for '%s'", path)
+        # We are only interested in the first (newest) commit
+        commits = self._repo.iter_commits(paths=path)
+        commit = next(commits)
+        last_changed = commit.committed_date
+        # We want to have a timezone-aware date
+        return datetime.utcfromtimestamp(last_changed)
 
     def blame(self, path):
         # TODO Implement...

--- a/zubbi/scraper/repos/git.py
+++ b/zubbi/scraper/repos/git.py
@@ -58,9 +58,7 @@ class GitRepository(Repository):
                 )
         else:
             try:
-                repo = Repo.clone_from(
-                    self.remote_url, repo_src_path, bare=True, depth=1
-                )
+                repo = Repo.clone_from(self.remote_url, repo_src_path, bare=True)
             except GitCommandError as e:
                 LOGGER.error("Cloning repo '%s' failed: %s" % (self.repo_name, e))
 


### PR DESCRIPTION
To make this work, we - unfortunately - have to remove the `shallow` clone option
and clone the repository with it's full history. Otherwise, we will always
retrieve the latest commit for each operation.

1. Implement `last_changed()` in Git repo class
2. Implement `blame()` in Git repo class