### PR TITLE
Upgrade docker alpine from 3.7 to 3.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # NOTE: This Dockerfile should only be used for demonstration purposes and not
 # in a production system. Flask is running in development mode and listens on
 # all public IPs to make it reachable from outside the docker container.
-FROM alpine:3.7
+FROM alpine:3.9
 
 WORKDIR /opt
 


### PR DESCRIPTION
 -  fix the build of pyzmq when installing by pip3