### PR TITLE
Allow custom tabs/contents on the details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.2.0
+
+### New Features
+- **UI:** Autofocus the search field on index page. You can now visit Zubbi and
+  directly start typing.
+- **UI:** Show "last update" timestamps for jobs and roles in search results.
+- **Extensions:** Allow custom tabs/contents on details page. When extending Zubbi,
+  someone can now add new tabs (in addition to the already existing 'Description'
+  and 'Changelog').
+
+### Fixes
+- **UI:** Use rendered description in search result cards to hide unparsable
+  Sphinx links.
+
+
 ## 1.1.0
 
 ### New Features

--- a/zubbi/static/style.css
+++ b/zubbi/static/style.css
@@ -117,7 +117,7 @@ a.vertical-tab:hover {
 }
 
 /* Description on details page */
-.block-description, .block-changelog {
+.block-tab-content {
     padding: 1.25rem .5rem;
 }
 

--- a/zubbi/templates/details.html
+++ b/zubbi/templates/details.html
@@ -86,6 +86,7 @@
           {% if block.changelog is defined %}
               <li class="nav-item"><a class="nav-link {% if not block.changelog %}disabled{% endif %}" href="#changelog">Changelog</a></li>
           {% endif %}
+          {% block additional_content_tab_headers %}{% endblock %}
       </ul>
 
       <div class="tab-content">
@@ -95,6 +96,7 @@
           <div id="changelog" class="tab-pane">
               {% include 'includes/block-changelog.html' %}
           </div>
+          {% block additional_content_tabs %}{% endblock %}
       </div>
 </div>
 {% endblock %}

--- a/zubbi/templates/includes/block-changelog.html
+++ b/zubbi/templates/includes/block-changelog.html
@@ -1,4 +1,4 @@
-<div class="block-changelog">
+<div class="block-tab-content block-changelog">
     {% if block.changelog_rendered %}
         {{ block.changelog_rendered }}
         {% if not block.has_html_changelog %}

--- a/zubbi/templates/includes/block-description.html
+++ b/zubbi/templates/includes/block-description.html
@@ -1,4 +1,4 @@
-<div class="block-description">
+<div class="block-tab-content block-description">
     {% if block.description_rendered %}
         {{ block.description_rendered }}
         {# If the description is not html, we show the link to the how-to #}


### PR DESCRIPTION
When extending Zubbi, someone can now add new tabs (in addition to the
already existing 'Description' and 'Changelog').