### PR TITLE
Overwrite ES index names with prefix from config, add tests for elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+
+### New Features
+- **Experimental:** You can set an `ES_INDEX_PREFIX` in the `settings.cfg` file to
+  prefix all Elasticsearch indices with a custom value. This could be useful to avoid
+  name clashes if indices with the same name are already used by another part of the
+  system.
+
 ## 1.2.0
 
 ### New Features
@@ -13,7 +21,6 @@
 ### Fixes
 - **UI:** Use rendered description in search result cards to hide unparsable
   Sphinx links.
-
 
 ## 1.1.0
 

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -3,6 +3,9 @@ ES_HOST = '<elasticsearch_host>'
 ES_PORT = 9200  # default
 ES_USER = '<user>'
 ES_PASSWORD = '<password>'
+# Optional, to avoid name clashes with existing ES indices from other applications
+# E.g. 'zubbi' will result in indices like 'zubbi-zuul-jobs', 'zubbi-ansible-roles', ...
+ES_INDEX_PREFIX = '<prefix>'
 
 # Scraper configuration
 # NOTE: The connection names must go in hand with the ones used in the tenant

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -282,8 +282,11 @@ def init_elasticsearch_con(
         # up in messy index names
         es_index_prefix = es_index_prefix.rstrip("-")
         for idx_cls in [ZuulJob, AnsibleRole, ZuulTenant, GitRepo]:
-            # idx_cls.Index.name = "{}-{}".format(es_index_prefix, idx_cls.Index.name)
-            idx_cls._index._name = "{}-{}".format(es_index_prefix, idx_cls._index._name)
+            # NOTE (felix): Index.name seems to hold the constant value that we defined
+            # in our index-meta class for the document. _index._name on the other hand
+            # holds the active value. Thus, we can use this to ensure that the prefix
+            # is only prepended once, even if we call this method multiple times.
+            idx_cls._index._name = "{}-{}".format(es_index_prefix, idx_cls.Index.name)
 
     ZuulJob.init()
     AnsibleRole.init()

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -247,6 +247,7 @@ def init_elasticsearch(app):
         app.config.get("ES_USER"),
         app.config.get("ES_PASSWORD"),
         app.config.get("ES_PORT"),
+        app.config.get("ES_INDEX_PREFIX"),
     )
 
     app.add_template_test(role_type)
@@ -254,7 +255,9 @@ def init_elasticsearch(app):
     app.add_template_filter(block_type)
 
 
-def init_elasticsearch_con(host, user=None, password=None, port=None):
+def init_elasticsearch_con(
+    host, user=None, password=None, port=None, es_index_prefix=None
+):
     http_auth = None
     # Set authentication parameters if available
     if user and password:
@@ -262,6 +265,25 @@ def init_elasticsearch_con(host, user=None, password=None, port=None):
     if port is None:
         port = DEFAULT_ES_PORT
     connections.create_connection(host=host, http_auth=http_auth, port=port)
+
+    # NOTE (felix): Hack to override the index names with prefix from config
+    # TODO (felix): Remove this once https://github.com/elastic/elasticsearch-dsl-py/pull/1099
+    # is merged and use the pattern described in the elasticsearch-dsl documentation
+    # https://elasticsearch-dsl.readthedocs.io/en/latest/persistence.html#index
+    #
+    # Unfortunately, this pattern is currently only working for document.init(),
+    # while the search() and save() methods will still use the original index name
+    # set in the index-meta class.
+    # This unexpected behaviour is also described in
+    # https://github.com/elastic/elasticsearch-dsl-py/issues/1121 and
+    # https://github.com/elastic/elasticsearch-dsl-py/issues/1091.
+    if es_index_prefix is not None:
+        # If the user set a '-' at the end of the prefix, we don't want to end
+        # up in messy index names
+        es_index_prefix = es_index_prefix.rstrip("-")
+        for idx_cls in [ZuulJob, AnsibleRole, ZuulTenant, GitRepo]:
+            # idx_cls.Index.name = "{}-{}".format(es_index_prefix, idx_cls.Index.name)
+            idx_cls._index._name = "{}-{}".format(es_index_prefix, idx_cls._index._name)
 
     ZuulJob.init()
     AnsibleRole.init()

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -283,6 +283,7 @@ def init_connections(config):
         config.get("ES_USER"),
         config.get("ES_PASSWORD"),
         config.get("ES_PORT"),
+        config.get("ES_INDEX_PREFIX"),
     )
 
     connections = {}


### PR DESCRIPTION
This is only a hack as the 'official' pattern described in the
elasticsearch-dsl documentation does not work as expected. Once
this is working, we should remove this hack and use the official
pattern instead.

For a  detailed description see https://github.com/bmwcarit/zubbi/issues/37#issuecomment-467775826

I've also added some tests for elasticsearch.

Should fix https://github.com/bmwcarit/zubbi/issues/37