### PR TITLE
Fix push event handling for missing repositories, add tests and improve logging

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from unittest import mock
@@ -224,6 +225,24 @@ def readme_yaml_code():
 @pytest.fixture(scope="function")
 def readme_supported_os():
     return raw_file("readmes/supported-os.rst")
+
+
+@pytest.fixture(scope="function")
+def payload_webhook_installation_created():
+    content = raw_file("payloads/github-webhook-installation-created.json")
+    return json.loads(content)
+
+
+@pytest.fixture(scope="function")
+def payload_webhook_installation_deleted():
+    content = raw_file("payloads/github-webhook-installation-deleted.json")
+    return json.loads(content)
+
+
+@pytest.fixture(scope="function")
+def payload_webhook_push():
+    content = raw_file("payloads/github-webhook-push.json")
+    return json.loads(content)
 
 
 @pytest.fixture(scope="function")

--- a/tests/scraper/test_events.py
+++ b/tests/scraper/test_events.py
@@ -1,0 +1,140 @@
+# Copyright 2018 BMW Car IT GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from zubbi.scraper.connections.github import GitHubConnection
+from zubbi.scraper.main import event_installation, event_push, handle_event
+
+
+@pytest.fixture(scope="function")
+def patched_connections():
+    # For the webhook part, we have to ensure a connection named "github"
+    connections = {
+        "github": GitHubConnection(
+            app_id=1,
+            app_key="tests/testdata/app_key_file",
+            url="https://github.example.com",
+        )
+    }
+    return connections
+
+
+def test_unknown_event(patched_connections):
+    # An unknown event shouldn't do anything, neither throw an exception
+    handle_event(
+        "unknown", None, patched_connections, tenant_parser=None, repo_cache=None
+    )
+
+
+@mock.patch("zubbi.scraper.main.scrape_repo_list")
+def test_event_installation_created(
+    scrape_mock, patched_connections, payload_webhook_installation_created
+):
+    # NOTE (felix): When testing the event handling, it should be enough to
+    # check if the correct methods are called in the correct ways. The
+    # functionality of those methods should be tested somewhere else.
+    event_installation(
+        payload_webhook_installation_created,
+        patched_connections,
+        tenant_parser=None,
+        repo_cache=None,
+    )
+
+    # Ensure that the scrape method is called with the correct list of repositories
+    assert scrape_mock.call_args == mock.call(
+        [
+            "zubbi-oss/testsub1",
+            "zubbi-oss/testsub2",
+            "zubbi-oss/testbase1",
+            "zubbi-oss/demo",
+            "playground/testsub3",
+        ],
+        patched_connections,
+        None,
+        repo_cache=None,
+    )
+
+
+@mock.patch("zubbi.scraper.main.scrape_repo_list")
+def test_event_installation_deleted(
+    scrape_mock, patched_connections, payload_webhook_installation_deleted
+):
+
+    # Ensure that some repositories can be looked up for this installation as they
+    # are not part of the payload for a delete event.
+    with mock.patch(
+        "zubbi.scraper.connections.github.GitHubConnection.get_repos_for_installation",
+        return_value=["org/foo", "org/bar"],
+    ):
+        event_installation(
+            payload_webhook_installation_deleted,
+            patched_connections,
+            tenant_parser=None,
+            repo_cache=None,
+        )
+
+    # Ensure that the scrape method is called with the correct list of repos
+    # and the delete_only flag.
+    assert scrape_mock.call_args == mock.call(
+        ["org/foo", "org/bar"],
+        patched_connections,
+        None,
+        repo_cache=None,
+        delete_only=True,
+    )
+
+
+@mock.patch("zubbi.scraper.main.scrape_repo_list")
+def test_event_push(scrape_mock, patched_connections, payload_webhook_push):
+    # Ensure that the repository from the payload is part of our GitHub connection
+    # and has a valid default branch.
+    gh_con = patched_connections.get("github")
+    gh_con.installation_map = {"zubbi-oss/testsub1": {"default_branch": "master"}}
+
+    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+
+    # Ensure that the scrape method is called with the correct list of repositories
+    assert scrape_mock.call_args == mock.call(
+        ["zubbi-oss/testsub1"], patched_connections, None, repo_cache=None
+    )
+
+
+@mock.patch("zubbi.scraper.connections.github.GitHubConnection._prime_install_map")
+def test_event_push_missing_repo(
+    scrape_reprime, patched_connections, payload_webhook_push
+):
+    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+
+    # As we did not add the required repository to our GitHub connection, it should
+    # try to re-init the installation map.
+    assert scrape_reprime.call_count == 1
+
+
+@mock.patch("zubbi.scraper.main.scrape_repo_list")
+def test_event_push_invalid_branch(
+    scrape_mock, patched_connections, payload_webhook_push
+):
+    # Ensure that the repository from the payload is part of our GitHub connection and has
+    # a default branch other than "master".
+    gh_con = patched_connections.get("github")
+    gh_con.installation_map = {"zubbi-oss/testsub1": {"default_branch": "not-master"}}
+
+    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+
+    # As the branch from the payload is different from the default branch we defined above,
+    # the event shouldn't be handled, and thus the scrape method shouldn't have been called.
+    assert not scrape_mock.called

--- a/tests/testdata/payloads/github-webhook-installation-created.json
+++ b/tests/testdata/payloads/github-webhook-installation-created.json
@@ -1,0 +1,38 @@
+{
+  "action": "created",
+  "installation": {
+    "id": 147
+  },
+  "repositories": [
+    {
+      "id": 69,
+      "name": "testsub1",
+      "full_name": "zubbi-oss/testsub1",
+      "private": false
+    },
+    {
+      "id": 70,
+      "name": "testsub2",
+      "full_name": "zubbi-oss/testsub2",
+      "private": false
+    },
+    {
+      "id": 71,
+      "name": "testbase1",
+      "full_name": "zubbi-oss/testbase1",
+      "private": false
+    },
+    {
+      "id": 1694,
+      "name": "demo",
+      "full_name": "zubbi-oss/demo",
+      "private": true
+    },
+    {
+      "id": 2277,
+      "name": "testsub3",
+      "full_name": "playground/testsub3",
+      "private": false
+    }
+  ]
+}

--- a/tests/testdata/payloads/github-webhook-installation-deleted.json
+++ b/tests/testdata/payloads/github-webhook-installation-deleted.json
@@ -1,0 +1,6 @@
+{
+  "action": "deleted",
+  "installation": {
+    "id": 153
+  }
+}

--- a/tests/testdata/payloads/github-webhook-push.json
+++ b/tests/testdata/payloads/github-webhook-push.json
@@ -1,0 +1,15 @@
+{
+  "ref": "refs/heads/master",
+  "before": "e4fb09580b8c80010209755738f14eeae39c8b77",
+  "after": "f0576aa54bbcf384a9998c7f7aee3ca43d09a6a1",
+  "commits": [],
+  "repository": {
+    "id": 5189,
+    "name": "testsub1",
+    "full_name": "zubbi-oss/testsub1",
+    "private": false
+  },
+  "installation": {
+    "id": 138
+  }
+}

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -545,7 +545,7 @@ def delete_outdated(scrape_time, indices, extra_filter=None):
 # TODO (fschmidt): Maybe it's worth to move the event_* methods to a GitHubEventHandler
 # class or similar. This way, we could encapsulate different events in their respective
 # environment (e.g. GitHub, Gerrit, ...)
-def handle_event(event, payload, config, connections, tenant_parser, repo_cache):
+def handle_event(event, payload, connections, tenant_parser, repo_cache):
     LOGGER.info("Handling event '%s'", event)
     try:
         # TODO (fschmidt): Maybe we should change this file/module to be a class
@@ -562,14 +562,14 @@ def handle_event(event, payload, config, connections, tenant_parser, repo_cache)
         # TODO (fschmidt): What about 'repository' events?
         # To get updates for public/private?
         # https://developer.github.com/v3/activity/events/types/#repositoryevent
-        method(payload, config, connections, tenant_parser, repo_cache)
+        method(payload, connections, tenant_parser, repo_cache)
     except Exception:
         # TODO (fschmidt): Does it make sense to catch an Exception here?
         # Could we catch anything more specific?
         LOGGER.exception("Error while handling event '%s'", event)
 
 
-def event_installation(payload, config, connections, tenant_parser, repo_cache):
+def event_installation(payload, connections, tenant_parser, repo_cache):
     action = payload.get("action")
     installation_id = payload.get("installation", {}).get("id")
     repositories = payload.get("repositories", [])
@@ -614,9 +614,7 @@ def event_installation(payload, config, connections, tenant_parser, repo_cache):
         # TODO (fschmidt): Should we remove them also from the installatino map?
 
 
-def event_installation_repositories(
-    payload, config, connections, tenant_parser, repo_cache
-):
+def event_installation_repositories(payload, connections, tenant_parser, repo_cache):
     installation_id = payload.get("installation", {}).get("id")
     repos_added = payload.get("repositories_added")
     repos_removed = payload.get("repositories_removed")
@@ -660,7 +658,7 @@ def event_installation_repositories(
         )
 
 
-def event_push(payload, config, connections, tenant_parser, repo_cache):
+def event_push(payload, connections, tenant_parser, repo_cache):
     repo_name = payload.get("repository", {}).get("full_name")
     # installation_id = payload.get('installation', {}).get('id')
     ref = payload.get("ref")


### PR DESCRIPTION
Changes:

37ee31c (Felix Schmidt, 3 months ago)
   Add mocked tests for GitHub webhook handling

4a2c4ce (Felix Schmidt, 3 hours ago)
   Improve logging in webhook handle functions

30ee71b (Felix Schmidt, 4 months ago)
   Remove unused 'config' parameter from event_* methods

4231e11 (Felix Schmidt, 19 hours ago)
   Reinitialize installation map if repo is not found during push event

   In this case, we might have missed the appropriate create/add event for
   this repository and thus need to re-initialize our installatino map.