### PR TITLE
Fix some bugs in the repo parser and update repo information is ES directly after scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 2.0.0
 
+### New Features
+- **Scraper:** Update repo information in Elasticsearch directly after scraping.
+  Previously, we updated the information for all scraped repositories in one go to
+  reduce the amount of requests sent to Elasticsearch. However, this had the drawback,
+  that none of the repo information was updated if scraping any of the repositories
+  failed.
+
+### Fixes
+- **Scraper:** Fix a bug were the scraper was still trying to check out GitHub
+  repositories, although it didn't have a valid access token.
+- **Scraper:** Don't fail when trying to split the owner from an invalid GitHub
+  repository names. Actually, the wrong name comes from a bug in the tenant scraper
+  which should be fixed in a future release. But for now, it's a good idea to make
+  this part more robust.
+
 ### Backwards incompatible changes
 - **Elasticsearch:** Zubbi 2.x.x is only compatible with Elasticsearch major version 7.
 

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -438,7 +438,6 @@ def _scrape_repo_map(
         ZuulTenant.bulk_save(tenant_list)
 
         LOGGER.info("Scraping the following repositories: %s", repo_list)
-        es_repos = []
 
         for repo_name, repo_data in repo_map.items():
             # Extract the data from the repo_data
@@ -482,14 +481,13 @@ def _scrape_repo_map(
             es_repo.repo_name = repo_name
             es_repo.scrape_time = scrape_time
             es_repo.provider = provider
-            es_repos.append(es_repo)
 
             # scrape the repo if is part of the tenant config
             scrape_repo(repo, tenants, scrape_time)
 
-        # Store the information for all repos we just scraped in Elasticsearch
-        LOGGER.info("Updating %d repo definitions in Elasticsearch", len(es_repos))
-        GitRepo.bulk_save(es_repos)
+            # Store the information for the repository itself, if it was scraped successfully
+            LOGGER.info("Updating repo definition for '%s' in Elasticsearch", repo_name)
+            GitRepo.bulk_save([es_repo])
     else:
         # Delete the repositories from the repo_cache
         for repo_name in repo_list:

--- a/zubbi/scraper/repos/github.py
+++ b/zubbi/scraper/repos/github.py
@@ -139,9 +139,10 @@ class GitHubRepository(Repository):
 
     def _get_repo_object(self):
         owner, repo_name = self.repo_name.split("/")
-        repo = self.gh_con.create_github_client(self.repo_name).repository(
-            owner=owner, repository=repo_name
-        )
+        gh_client = self.gh_con.create_github_client(self.repo_name)
+        if gh_client is None:
+            return None
+        repo = gh_client.repository(owner=owner, repository=repo_name)
         return repo
 
     def url_for_file(self, file_path, highlight_start=None, highlight_end=None):

--- a/zubbi/scraper/repos/github.py
+++ b/zubbi/scraper/repos/github.py
@@ -142,10 +142,10 @@ class GitHubRepository(Repository):
             owner, repo_name = self.repo_name.split("/")
         except ValueError:
             LOGGER.error("Invalid repo name '%s'", self.repo_name)
-            return None
+            return
         gh_client = self.gh_con.create_github_client(self.repo_name)
         if gh_client is None:
-            return None
+            return
         repo = gh_client.repository(owner=owner, repository=repo_name)
         return repo
 

--- a/zubbi/scraper/repos/github.py
+++ b/zubbi/scraper/repos/github.py
@@ -138,7 +138,11 @@ class GitHubRepository(Repository):
         return flat_blame
 
     def _get_repo_object(self):
-        owner, repo_name = self.repo_name.split("/")
+        try:
+            owner, repo_name = self.repo_name.split("/")
+        except ValueError:
+            LOGGER.error("Invalid repo name '%s'", self.repo_name)
+            return None
         gh_client = self.gh_con.create_github_client(self.repo_name)
         if gh_client is None:
             return None


### PR DESCRIPTION
a8312e7 (Felix Schmidt, 17 minutes ago)
   Avoid splitting invalid GH repository names

   This invalid repo name actually comes from a bug in the tenant config 
   parser, which results in a repo 'include' that cannot be split into
   (owner, /, repo). Thus, the error should be fixed directly in the tenant 
   parser. Still, I find it's a good idea to make this part more robust and
   avoid similar errors in the future.

d973b9a (Felix Schmidt, 18 hours ago)
   Update repo information in ES directly after scraping

   Previously, the repo information for all scraped repositories was updated
   after all repos were scraped. If the scraping of a single repository
   failed, none of the repos were updated in ES.

   As the repo information itself are only used for the `list-repos` command
   so far, this is not a blocker, but still, the behaviour is not very nice.

eb17cd8 (Felix Schmidt, 19 hours ago)
   Skip scraping for GH repositories if we have no access