### PR TITLE
Allow SSL parameters for ES connection and simplify ES notation in settings file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.1.0
+
+### New Features
+- **Elasticsearch:** Support SSL options for the Elasticsearch connection. For a
+  list of available options, take a look at the settings.cfg.example file.
+
+### Deprecated
+- **Configuration:** Changed the format on how to specify the Elasticsearch
+  connection in the config file to a single dictionary (like for CONNECTIONS).
+  The old format (prefixing everything with "ES_") is still supported but will
+  be removed in future versions. Please see the settings.cfg.example for details
+  to the new format.
+
 ## 2.0.0
 
 ### New Features

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -1,11 +1,21 @@
 # global configuration
-ES_HOST = '<elasticsearch_host>'
-ES_PORT = 9200  # default
-ES_USER = '<user>'
-ES_PASSWORD = '<password>'
-# Optional, to avoid name clashes with existing ES indices from other applications
-# E.g. 'zubbi' will result in indices like 'zubbi-zuul-jobs', 'zubbi-ansible-roles', ...
-ES_INDEX_PREFIX = '<prefix>'
+ELASTICSEARCH = {
+    'host': '<elasticsearch_host>',
+    'port': 9200,  # default
+    'user': '<user>',
+    'password': '<password>',
+    # Optional, to avoid name clashes with existing ES indices from other applications
+    # E.g. 'zubbi' will result in indices like 'zubbi-zuul-jobs', 'zubbi-ansible-roles', ...
+    index_prefix: '<prefix>',
+    # Optional, to enable SSL for the Elasticsearch connection.
+    # You must at least set 'enabled' to True and provide other parameters if the default
+    # values are not sufficient.
+    'tls': {
+        'enabled': False,  # default
+        'check_hostname': True,  # default
+        'verify_mode': 'CERT_REQUIRED',  # default
+    },
+}
 
 # Scraper configuration
 # NOTE: The connection names must go in hand with the ones used in the tenant

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -24,7 +24,7 @@ def elmock():
     for idx_cls in [ZuulJob, AnsibleRole, ZuulTenant, GitRepo]:
         # As the Index.name attribute holds the constant value from the original
         # definition, we can use it to reset the active value which might have
-        # changed due to the es_index_prefix hack.
+        # changed due to the index_prefix hack.
         idx_cls._index._name = idx_cls.Index.name
 
 
@@ -98,7 +98,7 @@ def test_elasticsearch_init_with_prefix(elmock):
         lambda index: index in existing_indices
     )
 
-    init_elasticsearch_con("127.0.0.1", "user", "password", es_index_prefix="zubbi")
+    init_elasticsearch_con("127.0.0.1", "user", "password", index_prefix="zubbi")
 
     # Validate that the Elasticsearch() (which is called by elasticsearch-dsl in the end)
     # was called with the correct arguments.
@@ -137,8 +137,8 @@ def test_elasticsearch_init_with_prefix_multi(elmock):
         lambda index: index in existing_indices
     )
 
-    init_elasticsearch_con("127.0.0.1", "user", "password", es_index_prefix="zubbi")
-    init_elasticsearch_con("127.0.0.1", "user", "password", es_index_prefix="zubbi")
+    init_elasticsearch_con("127.0.0.1", "user", "password", index_prefix="zubbi")
+    init_elasticsearch_con("127.0.0.1", "user", "password", index_prefix="zubbi")
 
     # Evenv if we called the init() method multiple times, the index should only be
     # prepended once.
@@ -165,7 +165,7 @@ def test_elasticsearch_write(elmock):
 
 
 def test_elasticsearch_write_with_prefix(elmock):
-    init_elasticsearch_con("127.0.0.1", "user", "password", es_index_prefix="zubbi")
+    init_elasticsearch_con("127.0.0.1", "user", "password", index_prefix="zubbi")
 
     zt = ZuulTenant(name="foo")
     zt.save()

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,3 +1,4 @@
+import ssl
 from unittest import mock
 
 import elasticsearch_dsl
@@ -27,6 +28,29 @@ def elmock():
         idx_cls._index._name = idx_cls.Index.name
 
 
+def test_elasticsearch_init_ssl_defaults(elmock):
+    tls_config = {"enabled": True}
+    init_elasticsearch_con("127.0.0.1", "user", "password", 443, tls=tls_config)
+
+    # Use single assertion for each argument as we can't compare the ssl_context so easily
+    kwargs = elmock.call_args[1]
+    assert kwargs["port"] == 443
+    assert kwargs["use_ssl"] is True
+    assert kwargs["ssl_context"].check_hostname is True
+    assert kwargs["ssl_context"].verify_mode == ssl.CERT_REQUIRED
+
+
+def test_elasticsearch_init_ssl(elmock):
+    tls_config = {"enabled": True, "check_hostname": False, "verify_mode": "CERT_NONE"}
+    init_elasticsearch_con("127.0.0.1", "user", "password", 443, tls=tls_config)
+
+    kwargs = elmock.call_args[1]
+    assert kwargs["port"] == 443
+    assert kwargs["use_ssl"] is True
+    assert kwargs["ssl_context"].check_hostname is False
+    assert kwargs["ssl_context"].verify_mode == ssl.CERT_NONE
+
+
 def test_elasticsearch_init(elmock):
 
     # Define the existing indices for the mock
@@ -43,6 +67,8 @@ def test_elasticsearch_init(elmock):
         host="127.0.0.1",
         port=9200,
         http_auth=("user", "password"),
+        use_ssl=False,
+        ssl_context=None,
         serializer=serializer,
     )
 
@@ -80,6 +106,8 @@ def test_elasticsearch_init_with_prefix(elmock):
         host="127.0.0.1",
         port=9200,
         http_auth=("user", "password"),
+        use_ssl=False,
+        ssl_context=None,
         serializer=serializer,
     )
 

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -251,14 +251,18 @@ def class_from_block_type(block_type):
 
 
 def init_elasticsearch(app):
-    init_elasticsearch_con(
-        app.config["ES_HOST"],
-        app.config.get("ES_USER"),
-        app.config.get("ES_PASSWORD"),
-        app.config.get("ES_PORT"),
-        app.config.get("ES_INDEX_PREFIX"),
-        app.config.get("ES_TLS"),
-    )
+    es_config = app.config.get("ELASTICSEARCH")
+    if es_config is None:
+        es_config = {
+            "host": app.config["ES_HOST"],
+            "user": app.config.get("ES_USER"),
+            "password": app.config.get("ES_PASSWORD"),
+            "port": app.config.get("ES_PORT"),
+            "index_prefix": app.config.get("ES_INDEX_PREFIX"),
+            "tls": app.config.get("ES_TLS"),
+        }
+
+    init_elasticsearch_con(**es_config)
 
     app.add_template_test(role_type)
     app.add_template_test(job_type)

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -270,7 +270,7 @@ def init_elasticsearch(app):
 
 
 def init_elasticsearch_con(
-    host, user=None, password=None, port=None, es_index_prefix=None, tls=None
+    host, user=None, password=None, port=None, index_prefix=None, tls=None
 ):
     http_auth = None
     # Set authentication parameters if available
@@ -308,16 +308,16 @@ def init_elasticsearch_con(
     # This unexpected behaviour is also described in
     # https://github.com/elastic/elasticsearch-dsl-py/issues/1121 and
     # https://github.com/elastic/elasticsearch-dsl-py/issues/1091.
-    if es_index_prefix is not None:
+    if index_prefix is not None:
         # If the user set a '-' at the end of the prefix, we don't want to end
         # up in messy index names
-        es_index_prefix = es_index_prefix.rstrip("-")
+        index_prefix = index_prefix.rstrip("-")
         for idx_cls in [ZuulJob, AnsibleRole, ZuulTenant, GitRepo]:
             # NOTE (felix): Index.name seems to hold the constant value that we defined
             # in our index-meta class for the document. _index._name on the other hand
             # holds the active value. Thus, we can use this to ensure that the prefix
             # is only prepended once, even if we call this method multiple times.
-            idx_cls._index._name = "{}-{}".format(es_index_prefix, idx_cls.Index.name)
+            idx_cls._index._name = "{}-{}".format(index_prefix, idx_cls.Index.name)
 
     ZuulJob.init()
     AnsibleRole.init()


### PR DESCRIPTION
Changes:

84d505b (Felix Schmidt, 26 seconds ago)
   Update CHANGELOG and settings.cfg.example

09b8fa6 (Felix Schmidt, 2 hours ago)
   Remove es_ prefix from index_prefix param for ES init function

bd93a76 (Felix Schmidt, 2 hours ago)
   Simplify notation for Elasticsearch configuration in config file

   This simplifies the notation for the Elasticsearch configuration in the
   settings.cfg. While the old format 'ES_*' is still compatible, we should
   remove that some time.

3309649 (Felix Schmidt, 2 hours ago)
   Allow SSL context options for Elasticsearch connection