### PR TITLE
Remove unnecessary config parameter for handle_event() method

### DIFF
--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -254,7 +254,6 @@ def scrape(ctx, full, repo):
                     handle_event(
                         event.decode("utf-8"),
                         json.loads(payload.decode("utf-8")),
-                        config,
                         connections,
                         tenant_parser,
                         repo_cache,


### PR DESCRIPTION
The handle_event() method was adapted somewhen in the past and it looks
like we didn't check this method in the meantime.