### PR TITLE
Fix deletion of outdated repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.2.1
+
+### Fixes
+- Fixed a bug where the delete outdated query never matched repositories on
+  Github. To fix this behaviour, an additional repo_name.keyword field was
+  introduced in the git-repos index.
+
+  To make this change take effect, please delete the old git-repos index. Zubbi
+  will automatically recreate it on startup. To keep the existing repo data you
+  could either back up and restore this data via the Elasticsearch
+  [reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html)
+  or let Zubbi do an initial full-scrape.
+
+## 2.2.0
+
+### General
+- Updated dependencies to newest versions
+
 ## 2.1.2
 
 ### Fixes

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -23,6 +23,7 @@ from elasticsearch_dsl import (
     Date,
     Document,
     Integer,
+    Keyword,
     Q,
     Search,
     Text,
@@ -71,7 +72,9 @@ class ZuulTenant(ZubbiDoc):
 
 
 class GitRepo(ZubbiDoc):
-    repo_name = Text()
+    # As the repo name contains a slash we must at least provide a Keyword()
+    # field to allow exact matches e.g. via term query.
+    repo_name = Text(fields={"keyword": Keyword()})
     provider = Text()
 
     class Index:


### PR DESCRIPTION
So far, the delete outdated query wasn't working for Github repositories at all due the slash that's usually contained in the repository name. This fix adds a Keyword field to the repo_name which will allow matching against whole repo names including the slash.