### PR TITLE
Implement 'reusable' directive for boosting reusable roles/jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## unreleased
+
+### New Features
+- **Scraper:** Support marking roles and jobs as "reusable". It parses the directive
+  in role's README file and job's description and store it in Elasticsearch.
+- **UI:** Search result will display roles and jobs that are marked as "reusable"
+  on top, and highlight them.
+
 ## 2.2.2
 
 ### General

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,11 @@ def readme_supported_os():
 
 
 @pytest.fixture(scope="function")
+def readme_reusable():
+    return raw_file("readmes/reusable.rst")
+
+
+@pytest.fixture(scope="function")
 def payload_webhook_installation_created():
     content = raw_file("payloads/github-webhook-installation-created.json")
     return json.loads(content)

--- a/tests/scraper/test_repo_parser.py
+++ b/tests/scraper/test_repo_parser.py
@@ -43,15 +43,18 @@ def test_parse(repo_data):
         "job_name": "my-cool-new-job",
         "repo": "my/project",
         "tenants": ["foo"],
-        "description": "This is just a job for testing purposes.\n",
+        "description": "This is just a job for testing purposes.\n\n"
+        ".. supported_os:: Linux\n\n"
+        ".. reusable:: True\n",
         "description_html": "<p>This is just a job for testing purposes.</p>\n",
         "parent": "cool-base-job",
         "url": "https://github/zuul.d/jobs.yaml",
         "private": False,
-        "platforms": [],
+        "platforms": ["linux"],
+        "reusable": True,
         "scrape_time": scrape_time,
         "line_start": 1,
-        "line_end": 7,
+        "line_end": 11,
         "last_updated": None,
     }
 
@@ -65,9 +68,10 @@ def test_parse(repo_data):
         "url": "https://github/zuul.d/jobs.yaml",
         "private": False,
         "platforms": [],
+        "reusable": False,
         "scrape_time": scrape_time,
-        "line_start": 8,
-        "line_end": 12,
+        "line_start": 12,
+        "line_end": 16,
         "last_updated": None,
     }
 
@@ -81,8 +85,9 @@ def test_parse(repo_data):
         "url": "https://github/zuul.d/jobs.yaml",
         "private": False,
         "platforms": [],
-        "line_start": 13,
-        "line_end": 17,
+        "reusable": False,
+        "line_start": 17,
+        "line_end": 21,
         "scrape_time": scrape_time,
         "last_updated": None,
     }
@@ -92,11 +97,13 @@ def test_parse(repo_data):
         "repo": "my/project",
         "tenants": ["foo", "bar"],
         "description": "Just some simple description\n\n"
-        ".. supported_os:: Linux, Windows\n",
+        ".. supported_os:: Linux, Windows\n\n"
+        ".. reusable:: True\n",
         "description_html": "<p>Just some simple description</p>\n",
         "url": "https://github/my/project/tree/master/roles/foo",
         "private": False,
         "platforms": ["linux", "windows"],
+        "reusable": True,
         "scrape_time": scrape_time,
         "last_updated": "2018-09-17 15:15:15",
     }
@@ -157,6 +164,7 @@ def test_parse(repo_data):
         "url": "https://github/my/project/tree/master/roles/bar",
         "private": False,
         "platforms": [],
+        "reusable": False,
         "scrape_time": scrape_time,
         "last_updated": "2018-09-17 15:15:15",
     }

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -81,3 +81,13 @@ def test_render_sphinx_supported_os(readme_supported_os):
 
     assert expected_platforms == result["platforms"]
     assert expected_html == result["html"]
+
+
+def test_render_sphinx_reusable(readme_reusable):
+    expected_reusable = True
+    expected_html = "<p>This is a reusable role!</p>\n"
+
+    result = render_sphinx(readme_reusable)
+
+    assert expected_reusable == result["reusable"]
+    assert expected_html == result["html"]

--- a/tests/testdata/readmes/reusable.rst
+++ b/tests/testdata/readmes/reusable.rst
@@ -1,0 +1,3 @@
+This is a reusable role!
+
+.. reusable:: true

--- a/tests/testdata/repo_files/roles/foo/README.rst
+++ b/tests/testdata/repo_files/roles/foo/README.rst
@@ -1,3 +1,5 @@
 Just some simple description
 
 .. supported_os:: Linux, Windows
+
+.. reusable:: True

--- a/tests/testdata/repo_files/zuul.d/jobs.yaml
+++ b/tests/testdata/repo_files/zuul.d/jobs.yaml
@@ -3,6 +3,10 @@
     parent: cool-base-job
     description: |
       This is just a job for testing purposes.
+
+      .. supported_os:: Linux
+
+      .. reusable:: True
     run: playbooks/non-existing-playbook.yaml
 
 - job:

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -204,7 +204,11 @@ class BlockSearch(Search):
 
         extra_filter = extra_filter or []
 
-        return self.query("bool", filter=extra_filter, must=search_query)
+        boost_reusable_query = Q("term", reusable={"value": True, "boost": 2})
+
+        return self.query(
+            "bool", filter=extra_filter, must=search_query, should=boost_reusable_query
+        )
 
     def detail_query(self, block_name, repo, extra_filter=None):
         extra_filter = extra_filter or []

--- a/zubbi/scraper/repo_parser.py
+++ b/zubbi/scraper/repo_parser.py
@@ -91,6 +91,7 @@ class RepoParser:
                         doc = render_sphinx(job.description)
                         job.description_html = doc["html"]
                         job.platforms = doc["platforms"]
+                        job.reusable = doc["reusable"]
                     except SphinxBuildError as exc:
                         LOGGER.warning(
                             "Description of job '%s' could not be "

--- a/zubbi/templates/search.html
+++ b/zubbi/templates/search.html
@@ -75,7 +75,7 @@ Search {%- if result is not none %} results for "{{ query }}"{%- endif %}
 <div class="row">
   <div class="card-columns col">
   {%- for match in row %}
-    <div class="card">
+    <div class="card{% if match.reusable %} border-primary{% endif %}">
       <div class="card-header">
         {% if match is role_type -%}
           <i class="fas fa-cubes"></i>


### PR DESCRIPTION
Not all roles and jobs in the configured tenants are meant to be reusable by others. In order to improve the search result in Zubbi, we add a new directive "reusable" to job description and roles' readme file to specify those meant to be reusable. And they will be displayed on top of the search result list.