### PR TITLE
Repos can be configured as reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **UI:** Improve search results ordering. The search results will be ordered by
   the priority of the fields matching the query. The priority is like the following:
   name -> description -> tenant/repo.
+- **Scraper** Projects(repositories) can be configured as "reusable" in settings.cfg.
+  When A repository is configured as "reusable", all jobs and roles scraped from this
+  repository are marked as "reusable".
 
 ## 2.3.0
 

--- a/tests/scraper/test_events.py
+++ b/tests/scraper/test_events.py
@@ -36,7 +36,12 @@ def patched_connections():
 def test_unknown_event(patched_connections):
     # An unknown event shouldn't do anything, neither throw an exception
     handle_event(
-        "unknown", None, patched_connections, tenant_parser=None, repo_cache=None
+        "unknown",
+        None,
+        patched_connections,
+        reusable_repos=[],
+        tenant_parser=None,
+        repo_cache=None,
     )
 
 
@@ -50,6 +55,7 @@ def test_event_installation_created(
     event_installation(
         payload_webhook_installation_created,
         patched_connections,
+        reusable_repos=[],
         tenant_parser=None,
         repo_cache=None,
     )
@@ -64,6 +70,7 @@ def test_event_installation_created(
             "playground/testsub3",
         ],
         patched_connections,
+        [],
         None,
         repo_cache=None,
     )
@@ -83,6 +90,7 @@ def test_event_installation_deleted(
         event_installation(
             payload_webhook_installation_deleted,
             patched_connections,
+            reusable_repos=[],
             tenant_parser=None,
             repo_cache=None,
         )
@@ -92,6 +100,7 @@ def test_event_installation_deleted(
     assert scrape_mock.call_args == mock.call(
         ["org/foo", "org/bar"],
         patched_connections,
+        [],
         None,
         repo_cache=None,
         delete_only=True,
@@ -105,11 +114,17 @@ def test_event_push(scrape_mock, patched_connections, payload_webhook_push):
     gh_con = patched_connections.get("github")
     gh_con.installation_map = {"zubbi-oss/testsub1": {"default_branch": "master"}}
 
-    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+    event_push(
+        payload_webhook_push,
+        patched_connections,
+        reusable_repos=[],
+        tenant_parser=None,
+        repo_cache=None,
+    )
 
     # Ensure that the scrape method is called with the correct list of repositories
     assert scrape_mock.call_args == mock.call(
-        ["zubbi-oss/testsub1"], patched_connections, None, repo_cache=None
+        ["zubbi-oss/testsub1"], patched_connections, [], None, repo_cache=None
     )
 
 
@@ -117,7 +132,13 @@ def test_event_push(scrape_mock, patched_connections, payload_webhook_push):
 def test_event_push_missing_repo(
     scrape_reprime, patched_connections, payload_webhook_push
 ):
-    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+    event_push(
+        payload_webhook_push,
+        patched_connections,
+        reusable_repos=[],
+        tenant_parser=None,
+        repo_cache=None,
+    )
 
     # As we did not add the required repository to our GitHub connection, it should
     # try to re-init the installation map.
@@ -133,7 +154,13 @@ def test_event_push_invalid_branch(
     gh_con = patched_connections.get("github")
     gh_con.installation_map = {"zubbi-oss/testsub1": {"default_branch": "not-master"}}
 
-    event_push(payload_webhook_push, patched_connections, None, repo_cache=None)
+    event_push(
+        payload_webhook_push,
+        patched_connections,
+        reusable_repos=[],
+        tenant_parser=None,
+        repo_cache=None,
+    )
 
     # As the branch from the payload is different from the default branch we defined above,
     # the event shouldn't be handled, and thus the scrape method shouldn't have been called.

--- a/tests/testdata/repo_files/zuul.d/jobs.yaml
+++ b/tests/testdata/repo_files/zuul.d/jobs.yaml
@@ -19,3 +19,7 @@
     description: |
       This is a base job with explicitly no parent.
     parent: null
+
+- job:
+    name: no-description-job
+    parent: null

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -18,6 +18,7 @@ import ssl
 import jinja2
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import (
+    Boolean,
     Completion,
     connections,
     Date,
@@ -106,6 +107,7 @@ class Block(ZubbiDoc):
     description_html = Text()
     platforms = Text(multi=True, analyzer="whitespace")
     last_updated = Date(default_timezone="UTC")
+    reusable = Boolean()
 
     @staticmethod
     def suggest_field():

--- a/zubbi/scraper/repo_parser.py
+++ b/zubbi/scraper/repo_parser.py
@@ -28,9 +28,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class RepoParser:
-    def __init__(self, repo, tenants, job_files, role_files, scrape_time):
+    def __init__(
+        self, repo, tenants, job_files, role_files, scrape_time, is_reusable_repo
+    ):
         self.repo = repo
         self.tenants = tenants
+        self.is_reusable_repo = is_reusable_repo
         self.job_files = job_files
         self.role_files = role_files
         self.scrape_time = scrape_time
@@ -100,6 +103,9 @@ class RepoParser:
                             exc,
                         )
 
+                # If the repo is configured as reusable, all jobs are considered reusable
+                job.reusable = self.is_reusable_repo or bool(job.reusable)
+
                 # TODO (fschmidt): Look up the tenant.default-parent and
                 # use this one over 'base' if no parent is defined.
                 # If parent is explicitly set to None, we will keep it.
@@ -144,6 +150,9 @@ class RepoParser:
                 rendered_content = render_file(changelog_file)
                 if rendered_content:
                     role.changelog_html = rendered_content.pop("html")
+
+            # If the repo is configured as reusable, all roles are considered reusable
+            role.reusable = self.is_reusable_repo or bool(role.reusable)
 
             repo_roles.append(role)
 


### PR DESCRIPTION
When a repo is configured as reusable, all jobs and roles scraped from this repo are labled as "reusable" in zubbi.