### PR TITLE
Fix zubbi-scraper startup bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.4.3
+
+### Fixes
+- Fixed a bug that made the zubbi-scraper crash when a zuul config directory
+  contained not only files but a nested directory structure. Those config
+  directories are now scraped recursively.
+- Fixed a bug that made zubbi-scraper crash on startup if the TENANT_SOURCES_REPO
+  setting referenced an unknown connection.
+
+## 2.4.2
+
+### Fixes
+- Fixed a GraphQL query which was relying on a master branch being present in
+  the repository.
+
 ## 2.4.1
 
 ### Fixes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,10 +38,10 @@ class DummyRepo(Repository):
     def __init__(self, name):
         self._name = name
 
-    def check_out_file(self, file_path):
+    def file_contents(self, file_path):
         pass
 
-    def list_directory(self, directory_path):
+    def directory_contents(self, directory_path):
         pass
 
     def last_changed(self, path):

--- a/tests/scraper/connections/test_git.py
+++ b/tests/scraper/connections/test_git.py
@@ -53,7 +53,7 @@ def test_get_repo_object_failure(tmpdir):
     assert git_repo._repo is None
 
 
-def test_check_out_file(mock_git_repo, tmpdir):
+def test_file_contents(mock_git_repo, tmpdir):
     git_url = "https://localhost/git"
     repo_name = "foo"
 
@@ -61,11 +61,11 @@ def test_check_out_file(mock_git_repo, tmpdir):
         git_con = GitConnection(git_url, workspace=tmpdir)
         git_repo = GitRepository(repo_name, git_con)
 
-        contents = git_repo.check_out_file("README")
+        contents = git_repo.file_contents("README")
         assert contents == "Repository: foo"
 
 
-def test_check_out_non_existing_file(mock_git_repo, tmpdir):
+def test_non_existing_file_contents(mock_git_repo, tmpdir):
     git_url = "https://localhost/git"
     repo_name = "foo"
 
@@ -74,11 +74,11 @@ def test_check_out_non_existing_file(mock_git_repo, tmpdir):
         git_repo = GitRepository(repo_name, git_con)
 
         with pytest.raises(CheckoutError) as excinfo:
-            git_repo.check_out_file("non-existing-file")
+            git_repo.file_contents("non-existing-file")
         assert "Failed to check out 'non-existing-file'" in str(excinfo.value)
 
 
-def test_list_directory(mock_git_repo, tmpdir):
+def test_directory_contents(mock_git_repo, tmpdir):
     git_url = "https://localhost/git"
     repo_name = "foo"
 
@@ -86,14 +86,14 @@ def test_list_directory(mock_git_repo, tmpdir):
         git_con = GitConnection(git_url, workspace=tmpdir)
         git_repo = GitRepository(repo_name, git_con)
 
-        contents = git_repo.list_directory("/")
+        contents = git_repo.directory_contents("/")
         # The contents dict should contain an entry for the README file
         readme_contents = contents["README"]
         assert isinstance(readme_contents, FileContent)
         assert readme_contents.path == "README"
 
 
-def test_list_non_existing_directory(mock_git_repo, tmpdir):
+def test_non_existing_directory_contents(mock_git_repo, tmpdir):
     git_url = "https://localhost/git"
     repo_name = "foo"
 
@@ -102,5 +102,5 @@ def test_list_non_existing_directory(mock_git_repo, tmpdir):
         git_repo = GitRepository(repo_name, git_con)
 
         with pytest.raises(CheckoutError) as excinfo:
-            git_repo.list_directory("/non-existing-directory")
+            git_repo.directory_contents("/non-existing-directory")
         assert "Failed to check out '/non-existing-directory/'" in str(excinfo.value)

--- a/tests/scraper/test_integration.py
+++ b/tests/scraper/test_integration.py
@@ -70,6 +70,7 @@ class MockGitHubRepository(GitHubRepository):
                 )
             },
             "roles/docker-run/README.rst": MOCKED_ROLE_DESCRIPTION,
+            "roles/ignored": MockContents("not a valid role", MockContents.FILE),
         },
         "orga1/repo2": {
             "roles": {
@@ -104,7 +105,7 @@ class MockGitHubRepository(GitHubRepository):
         self.gh = mock.Mock()
         self._repo = repo_name
 
-    def list_directory(self, directory_path):
+    def directory_contents(self, directory_path):
         # Just list different files based on the given repo (which is the project
         # name in this case) and the directory_path
         try:
@@ -118,7 +119,7 @@ class MockGitHubRepository(GitHubRepository):
                 return {}
             raise CheckoutError("Directory {} does not exist in repo", directory_path)
 
-    def check_out_file(self, file_path):
+    def file_contents(self, file_path):
         # Just return different file contents based on the combination of
         # repo and file_path
         try:

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -86,12 +86,17 @@ def _initialize_tenant_parser(tenant_sources_repo, tenant_sources_file, connecti
         # Config entry must be in format <connection_name>:<repo>
         con_name, repo_name = tenant_sources_repo.split(":", 1)
         con = connections.get(con_name)
+        if not con:
+            raise ScraperConfigurationError(
+                f"Cannot load tenant sources from repo '{repo_name}'. "
+                f"Specified connection '{con_name}' is not avilable."
+            )
         provider = con.provider
         repo_class = REPOS.get(provider)
-        if not con or not repo_class:
+        if not repo_class:
             raise ScraperConfigurationError(
-                "Cannot load tenant sources from repo '{}'. Specified connection '{}' "
-                "is not available".format(repo_name, con_name)
+                f"Cannot load tenant sources from repo '{repo_name}'. "
+                f"Unknown connection provider '{provider}'."
             )
 
         repo = repo_class(repo_name, con)

--- a/zubbi/scraper/repos/__init__.py
+++ b/zubbi/scraper/repos/__init__.py
@@ -17,11 +17,11 @@ import abc
 
 class Repository(abc.ABC):
     @abc.abstractmethod
-    def check_out_file(self, file_path):
+    def file_contents(self, file_path):
         """Check out a single file of this repo."""
 
     @abc.abstractmethod
-    def list_directory(self, directory_path):
+    def directory_contents(self, directory_path):
         """List the content of a single directory of this repo."""
 
     @abc.abstractmethod

--- a/zubbi/scraper/repos/git.py
+++ b/zubbi/scraper/repos/git.py
@@ -69,7 +69,7 @@ class GitRepository(Repository):
 
         return repo
 
-    def check_out_file(self, file_path):
+    def file_contents(self, file_path):
         try:
             LOGGER.debug("Checking out '%s'", file_path)
             content = self._repo.git.show("{}:{}".format(DEFAULT_BRANCH, file_path))
@@ -77,7 +77,7 @@ class GitRepository(Repository):
         except GitCommandError as e:
             raise CheckoutError(file_path, e.stderr)
 
-    def list_directory(self, directory_path):
+    def directory_contents(self, directory_path):
         LOGGER.debug("Listing contents of '%s' directory", directory_path)
         command = ["git", "ls-tree", "--name-only", DEFAULT_BRANCH]
         # git ls-tree uses the root of the repository automatically, if no path is provided

--- a/zubbi/scraper/tenant_parser.py
+++ b/zubbi/scraper/tenant_parser.py
@@ -94,7 +94,7 @@ class TenantParser:
         LOGGER.info("Collecting tenant sources from repo '%s'", sources_repo)
         sources = []
         try:
-            tenants = sources_repo.list_directory(TENANTS_DIRECTORY)
+            tenants = sources_repo.directory_contents(TENANTS_DIRECTORY)
         except CheckoutError:
             raise ScraperConfigurationError(
                 "Cannot load tenant sources. Repo '{}' does not contain a "
@@ -103,10 +103,10 @@ class TenantParser:
 
         for tenant in tenants.keys():
             try:
-                sources_yaml = sources_repo.check_out_file(
+                sources_yaml = sources_repo.file_contents(
                     os.path.join("tenants", tenant, "sources.yaml")
                 )
-                settings_yaml = sources_repo.check_out_file(
+                settings_yaml = sources_repo.file_contents(
                     os.path.join("tenants", tenant, "settings.yaml")
                 )
                 # NOTE (fschmidt): We parse both files and create the same data


### PR DESCRIPTION
- Zuul job definition files are now parsed recursively
- Zubbi-scraper does not crash anymore if the TENANT_SOURCES_REPO setting references an unknown connection

See commit messages for further details.