### PR TITLE
Rename token in fixture for unittests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def github_response_access_token():
     expires_future = datetime.now(timezone.utc)
     expires_future += timedelta(minutes=10)
     response = {
-        "token": "v1.6a01e67ed5a45dff724d99694a325a090ab69419",
+        "token": "v1.token_foo",
         "expires_at": datetime.strftime(expires_future, "%Y-%m-%dT%H:%M:%SZ"),
     }
     return response

--- a/tests/scraper/connections/test_github.py
+++ b/tests/scraper/connections/test_github.py
@@ -58,6 +58,6 @@ def test_get_installation_key(mock_github_api_endpoints):
     }
 
     assert gh_con.installation_map == expected_installation_map
-    assert token_from_cache == "v1.6a01e67ed5a45dff724d99694a325a090ab69419"
-    assert token_for_project == "v1.6a01e67ed5a45dff724d99694a325a090ab69419"
+    assert token_from_cache == "v1.token_foo"
+    assert token_for_project == "v1.token_foo"
     assert isinstance(expires_at, datetime)


### PR DESCRIPTION
This seems to cause an issue with our security guidelines, so let's use
something less token-looking-like for the unittests.