### PR TITLE
Use explicit version of black in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.8.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
[WARNING] The 'rev' field of repo 'https://github.com/ambv/black'
appears to be a mutable reference (moving tag / branch).  Mutable
references are never updated after first install and are not supported.
See https://pre-commit.com/#using-the-latest-version-for-a-repository
for more details.  Hint: `pre-commit autoupdate` often fixes this.