### PR TITLE
Remove referrer header from zubbi repository link in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- Remove the noreferrer header from the zubbi repository link in the footer
+  to not leak internal URLs.
+
 ## 2.4.4
 
 ### Fixes

--- a/zubbi/templates/_footer.html
+++ b/zubbi/templates/_footer.html
@@ -1,7 +1,7 @@
 <footer class="footer" align="center">
     <span class="value">Version: {{ meta.version }}</span>
     <span class="value">
-        <a href="https://github.com/bmwcarit/zubbi">
+        <a href="https://github.com/bmwcarit/zubbi" rel="noopener noreferrer">
             <i class="fab fa-github pr-1"></i>Zubbi
         </a>
     </span>


### PR DESCRIPTION
To not leak internal URLs, we deactivate the referrer header for this
link.