### PR TITLE
Filter job files for .yaml extension and make parser more robust

### DIFF
--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -559,9 +559,14 @@ def scrape_repo(repo, tenants, reusable_repos, scrape_time):
     job_files, role_files = Scraper(repo).scrape()
 
     is_rusable_repo = repo.repo_name in reusable_repos
-    jobs, roles = RepoParser(
-        repo, tenants, job_files, role_files, scrape_time, is_rusable_repo
-    ).parse()
+    jobs = []
+    roles = []
+    try:
+        jobs, roles = RepoParser(
+            repo, tenants, job_files, role_files, scrape_time, is_rusable_repo
+        ).parse()
+    except Exception:
+        LOGGER.exception("Unable to parse job or role definitions in repo '%s'", repo)
 
     LOGGER.info("Updating %d job definitions in Elasticsearch", len(jobs))
     ZuulJob.bulk_save(jobs)

--- a/zubbi/scraper/repo_parser.py
+++ b/zubbi/scraper/repo_parser.py
@@ -19,6 +19,7 @@ import yaml
 from yaml.composer import Composer
 from yaml.constructor import Constructor
 from yaml.parser import ParserError
+from yaml.scanner import ScannerError
 
 from zubbi.doc import render_file, render_sphinx, SphinxBuildError
 from zubbi.models import AnsibleRole, ZuulJob
@@ -66,7 +67,7 @@ class RepoParser:
     def parse_job_definitions(self, file_path, job_info):
         try:
             jobs_yaml = yaml.load(job_info["content"], Loader=ZuulSafeLoader)
-        except ParserError as e:
+        except (ParserError, ScannerError) as e:
             LOGGER.warning("Error parsing file %s, error: %s", file_path, str(e))
             return []
 


### PR DESCRIPTION
**[Filter job files for .yaml extension before parsing](https://github.com/bmwcarit/zubbi/pull/94/commits/6f8c248c13958c33b80fa9bb89032c3bd7f05eb6)**

Zubbi expects the zuul.d directory to only contain valid yaml files.
Having something like a README.md file in between the job files will
make the parser fail as it doesn't contain valid yaml.

However, having such a file is totally fine for Zuul, so we should
adapt.

As a first step, we filter for `.yaml´ files in the scraper, so that the
parser doesn't need to take care of that.


**[Make RepoParser more robust against yaml errors](https://github.com/bmwcarit/zubbi/pull/94/commits/5edff9da78754cb2244eff449e8caeadb839a815)**

Even when filtering only for `.yaml` files in the scraper, we might end
up with a file that contains invalid yaml. Thus, make the repo parser
more robust against errors in yaml files.