### PR TITLE
Don't let zubbi-scraper crash on empty repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.7
+
+### Fixes
+- Fixed a bug that made zubbi-scraper crash on empty repositories.
+
 ## 2.4.6
 
 ### Fixes

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -31,11 +31,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51",
-                "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"
+                "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe",
+                "sha256:5ef4b3226b0180dedded4229651c8b0e1a3a6a2837d45a073272f313e4cf97f6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.10.3"
+            "version": "==2.11.0"
         },
         "bleach": {
             "hashes": [
@@ -148,89 +148,99 @@
         },
         "cmarkgfm": {
             "hashes": [
-                "sha256:00d6d5594629c07f1dc47265f8889e77600c9150065752dad0215027f413cf4e",
-                "sha256:0cfa29606c3a5517c9b8ccaafd8bf8e9bb670dd7e5e7c6f4ba3ffcc1a51f0901",
-                "sha256:14cf4725bb5dcc3f86d1ff10d06c01380f77c3b57c2af2dd99155ccc051f1983",
-                "sha256:37170a0b8dddc668971ed114e69f63994f2d22923a8f7e9049db0a98c4286c1d",
-                "sha256:3d87c90f7260c33e4760038e3c1084998df9b04e57f17e4e6ad923bce4616bd9",
-                "sha256:3fd912834f35bf1a7a0f92a6f91e0492272cab6259066b0f4b3fe3797d4af0ee",
-                "sha256:5c05a178fa92ef879fe3da7750689ee8e7ff92c1880811599472d1ef4a6a12ff",
-                "sha256:69c92e823292b806f7559cbd302d1b933d252cc4efc1fa653a229a0a36d72214",
-                "sha256:6acf21579980304081bd7f05336f4f42aa8368bc917961dd96e06f2bc0824bb7",
-                "sha256:6b7275ed10f77caddab233aa8b29a98551a73b4b4cdb6d0489dd2a6607183680",
-                "sha256:6c60079f47ca26751ac1faea3f22f11020f1b7819877a3e0003efb94952111a5",
-                "sha256:6cba4b1fd65946076aa85ee9940dade37d5535cc367590e62a8fa471f39e6406",
-                "sha256:6d0105fb2fd09e6fc6d6a2dd6e7f7b1e7d23a478543e8d3c9eb4f1c019a5f250",
-                "sha256:6d1a1f68bc4fa869f428653b5dc41a550b913d635c263840a3f929687ce2af4b",
-                "sha256:73cfa40881d756e30d8878da19477fdb080514fe28c3c9e48bcf8acf5fa6e232",
-                "sha256:77464966e707a2b3dffce81c61c21d5b42e980c507aed985acd6f4473f70c115",
-                "sha256:79a007195d8c62ac3dc4f52ff52001ad29e7f1f2ec9730c87e188995e55ef7dc",
-                "sha256:7f025e067938c7665844b08e6bae7004f8ae4c8939459270ab5eccb890cdd599",
-                "sha256:861b731166c6b1b1c2060f32cd45f534081b2154666d519d04d6f3a66a672fcb",
-                "sha256:87132a442131e4eaeddcba9984685edc30c83e14c8b372d37ed05d72972c46fd",
-                "sha256:88a196f5024409cbf4382fffcdcdcc47f068094445969e80159e605cf4dfcca9",
-                "sha256:8ee4121788c98c4f16b05a9c5d1577c2da403f7a46afcb297bb0721fe6be2a58",
-                "sha256:913b4c41c8e6e429f84df44c5c815a4969465edec71a0c1314028615ef598517",
-                "sha256:966c975be65f5fcb1e5d8c2787371ca2c0ad1d2672fe6b48da6861a9a6bb2c35",
-                "sha256:9dab877d499e51b962458a868b24bd38f6fd33daaa38e5e5a78278bbd824f859",
-                "sha256:9e0a2f00d76f325261fb96064ee0a053769cd7055440d46cfffa85e0d59c2e19",
-                "sha256:a0538e59e0805127dce77a11fa5e9706193b3637bb9a0a8d10b45fb1e56ae3fb",
-                "sha256:adb8c9344c49d8c2ceb9aeffe966a3fa839612d94ca540473f832fc1a3427e29",
-                "sha256:b098834079298d9401d2dd31030cd0c4abf9aef5c6198b05ff039dc6574ddc92",
-                "sha256:b56a6eeae7b80ef02db25f12812913e57d23838dba3757e0a56ae5a7aa9b46f8",
-                "sha256:b586ee395aaaadd874abbd268907de519d9a9ff2539aa87bc5ad1a01b26ad060",
-                "sha256:c2fcdb62e331d0714f91550f4492c9e64c1dd2756f0d504b375c03f165e201e6",
-                "sha256:c981c7011980241b3bfb4e801a8370c033a8cebfc43ee0880637c6f5597d4f04",
-                "sha256:cabd843b66d6907084dcb942fd4e1642775734113094d741da747a2c06e64ec3",
-                "sha256:cb9cf70cd73ca203c52b78a804bf87da091ac261df5524bc6e6852dd73f63812",
-                "sha256:cfa099b914725b925c02eecb50a1d491f61bbc7fb863c97b0ffe6b5bd2afd09b",
-                "sha256:d09910f0e98d588e55131f8f4ea156ba9e479824788feb37d20c0cfeed0a4764",
-                "sha256:d34395619808e3e40bde22434cada98f4840ebbe4fb9f444de505cf995e7d812",
-                "sha256:d508d045d54ebb47dbd9cd7a4287d01199fcc6a3987726041d3a548377811eeb",
-                "sha256:d69518534ae554ac8dc15bf093fbf66f9939b6eba2f3c91ae4421263522dda7b",
-                "sha256:dc7f4e4c696eff8708c5625887f26026d9115e07ed389d8262d94a23eab521dc",
-                "sha256:df8b6dd51a823724f274402424aff8fdde3778ec05b2dbb22768bcfb17bef34c",
-                "sha256:eec90234e586d0eef90dcd20bd5107f6b6ea5466cccd10f6c0a7449fb0726656",
-                "sha256:f43bec51976957300ed18296be3a4d859b12553c21b884223c1f3014062fa853",
-                "sha256:f5247716dc0f6538209865f976bfd9b6c0eebe229125f8487b0af3fc80713b56",
-                "sha256:f7bf22bb0925212b454a903ccd9172522581cc6ce80aad3e778a88959cad256b",
-                "sha256:fd75e332aa0d3f2b1cb1479b74b95d317e778112094838b77c74deb3539fc9b7",
-                "sha256:fdfe28c3b59cba9b678990d3b1d3d206c9651151a1099c60d21e4b7c9c69ab34",
-                "sha256:fe859b0e98d222b4b458022007daac2757e970f0671d45e55d01931c1b4bb3cb"
+                "sha256:0023de4b19bb557b143bed274f76cb36551f7f1d1cdffd29b6cde646b85d9ffb",
+                "sha256:0176d51fb57162c642b1d2c70048950a5ae119af81e77565a0383b992b1f86d6",
+                "sha256:071f5f0dac9475bab6a065878f248a69be52a7736b6c661e06ca7199f25fe097",
+                "sha256:0756ea0f6b55eff2617ea0518d6730e37d6077c10baaabbe8b46210ff5a250ef",
+                "sha256:07a06d424ccef98528cba1158946f92117e07579f1dc9942ed4fd70f81693b9f",
+                "sha256:1013ce61db1dd3febcaca1ee42cad9eb823852bb76cbae61c1488734ce51f2b7",
+                "sha256:123ad8d50fbedacd036760ba46e36170bad9dd2c1e83655d8622b7803169bb49",
+                "sha256:1790164f84e6b037d0b39df11f757e021a9f9c313681297a051d50bc7b5249fc",
+                "sha256:20e897160be161161a565df94ce502714a1aa63af3ad682e6d1f1c7e6656fdbb",
+                "sha256:210c0f0dbc1aadab30bc75c48b14b645414733a668df52b43058028e43a046e8",
+                "sha256:21557c06a411b1d754eed7f6fc9a8ff41f8a4a004b32c8bd2cec2ab3f3cb4d3c",
+                "sha256:216a540e85258839cffa7274731a87d91b3e17c9079b3b02467c312e784b5281",
+                "sha256:27149c63b1190ee6e7dd4b32d0a2c313bc1856bcdde7a42a0a5b6ae42d97ed94",
+                "sha256:325c03644da5ab81a7071aae6fbafa3beb22413f7fd7440baf6d510cfcf7be21",
+                "sha256:3f510fafa9d904336eecc3aa41536fd287c2d32baa21b14d48950ced802ca531",
+                "sha256:4325b75a3b5b802d5edcc2378aa6405a1e5df0aeeec583d1b05d73b0562fa7d0",
+                "sha256:47e267ce890b579585a32f77d347d61de2390b517cfc52bb4ca67c5c4b4c055a",
+                "sha256:483e48613f5c7b3350cdabfd0f69aaa086513542d0de533f39e5669bf4df5de4",
+                "sha256:5342c6d12e343cc66b4b8dcd09fc0c1977cb32fd1d57c15bd756876606591ee9",
+                "sha256:5a39333e1fdcd0116c24adc33423999913865bd3cc83fc44b2218aac7fbe5637",
+                "sha256:5bad39b832f734f588aea00868e53ba1aaf058d569e40e5c9016702edebf88e8",
+                "sha256:5fc7178a6afd69a5dfc197558791cecedead9fc77e95ec63c201e8219ce33000",
+                "sha256:6672784820981d315b695bb7ce08d40886502368e133b453d675ff6f2fffae49",
+                "sha256:670b414274edf3ecc0a950a80580e1de553c599a30658827a5d7f7bccbde5843",
+                "sha256:69a769feb1b2d16982fe952afd44e124a4d306a44cdfd6857e74b8eb5d47d765",
+                "sha256:76beb5b50b32d7bafec2154608a037601a2186d15df95cec6ab4cc937afca365",
+                "sha256:799cf03a82a7849d975a3b955798d5e439a08fb678b657c5078115dc61314674",
+                "sha256:7a91279ab8e2869c19120595e41ebd81a6f5034c1e6b1cfc5e81cd80d40bf3eb",
+                "sha256:80cf50b52bc0a47c032706de27b9526b6035c73b57ce06662021144cba4b6c5e",
+                "sha256:8744be702511464d04c34000005009607471f1afe65d6037777747d6b4607e5f",
+                "sha256:8830dfb61251f2b677dea7ffc531c3f6037f7e9a66a14ad24bdaf3cefe2dc8c4",
+                "sha256:89dcd4fea4ae44f1a0697cf805b6931a126b2b3ea23ed1ccdad7e020425224a9",
+                "sha256:8e9f038a4f0e54c135e468994f1ea97141b086d1f1bd8f498c12f3d559017e8e",
+                "sha256:90ae1b4b2c6b92f8f5b1e5416a2f5b1bba7a5f9aea29b0de79767ed80655527a",
+                "sha256:93d9ac7716ea901ca0bfd18ae3b68f1f6bf51de0830c3f233ef734fcd52a0799",
+                "sha256:98c0527153daf16589ef095aa72f06a4bdb9213433ff47811fbc4172c91d865b",
+                "sha256:a6a3970cf1c8ba4465d5046dd6a6d7f6024e67d6eec812a4701a21c5161a2fbd",
+                "sha256:b0b13eac6194d59f9d3ab44af7076221510e788572f34e25104ad47b33d960e1",
+                "sha256:b8daf62cddc81b31a8f3c9093936c4cb75b25a8024c09f276cb027f1647e3326",
+                "sha256:bd6315e1036d31884bff25719636e3499a7f4593b0f7b47dc742678328f2f26f",
+                "sha256:c04921575e412a6459d645a45ca987061b17d89310c92aedf108f97f2b8b7b91",
+                "sha256:c3a6e597bdf595f81dc214e821b579b8d665116c55ed5288b599ae941e446098",
+                "sha256:c66077349e7f7d954aa37d770310de5a8214ac9dca9756440f99e008a0e693de",
+                "sha256:c804446b941dc08dcc3d2def3913cfc4bae954b80babfaa2a502e8ebdea29185",
+                "sha256:c82af8cdb76a71459662e447f9b1545ae6146cb9287df978705a298f87a76a90",
+                "sha256:ca0e03a590c6f62738d208f8689da08eae9d3bcc2f4dd97e38df45d8dbc333ab",
+                "sha256:cc70b89309404dd84a524d439aa2b2e54872e0f623f9523bd77e66526251954f",
+                "sha256:ccfc25b5abfe1398426f099d840b5fa7dec118b44f06833e2ba8b67c6ffc12d9",
+                "sha256:cfe84b8912b355b8036c093ecdd6abbe6df075176879a49867dd72b9e53449f3",
+                "sha256:d3fd62dd65c3a64ced175a1447ea41b01a7ac1c0df1c8358323267c9326b7745",
+                "sha256:db3449fdb87752be5ad0698d6f2ca030af320cdf71ebc9a1ebae1b9c1d3661c8",
+                "sha256:ddc2bbb5572722758787066f5f841745c58452e28c59ce7c13b7228be1cb48f3",
+                "sha256:e65e492407d7cb3b695f3f715a1cbe6f97db69eb14011b8f156fc10c758b55c7",
+                "sha256:ea7d6cb95e2d74049cf08fde4ca6cbf030b9bf9ef75009847bbefb35094bb4c2",
+                "sha256:ea8a84d3702ccc32f8dfd0917dfb95f3d1843a0b6f85131c5cbfd1480d1d31ee",
+                "sha256:f17677e66f95f25999c959c3f5361c05e739ad4f6b70ab9fdd24b1734c3ab029",
+                "sha256:f2d3bdb7e525abd03366a57eabd03e0c3f3f36bbf8af2267200605b7b712763b",
+                "sha256:f938c503fce528d9cb715314134f8900cf09ddbd7e2bea88cf54a4bad58d0d5b",
+                "sha256:fbec94c3e91b5e03d90a2cc2e865179e5bc58673e92b03ba64b520a97a0e9219"
             ],
-            "version": "==0.8.0"
+            "version": "==2022.10.27"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a",
-                "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
-                "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0",
-                "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407",
-                "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7",
-                "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6",
-                "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153",
-                "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750",
-                "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
-                "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6",
-                "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b",
-                "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5",
-                "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a",
-                "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d",
-                "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d",
-                "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294",
-                "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0",
-                "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a",
-                "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac",
-                "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61",
-                "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013",
-                "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
-                "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb",
-                "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9",
-                "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd",
-                "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"
+                "sha256:068147f32fa662c81aebab95c74679b401b12b57494872886eb5c1139250ec5d",
+                "sha256:06fc3cc7b6f6cca87bd56ec80a580c88f1da5306f505876a71c8cfa7050257dd",
+                "sha256:25c1d1f19729fb09d42e06b4bf9895212292cb27bb50229f5aa64d039ab29146",
+                "sha256:402852a0aea73833d982cabb6d0c3bb582c15483d29fb7085ef2c42bfa7e38d7",
+                "sha256:4e269dcd9b102c5a3d72be3c45d8ce20377b8076a43cbed6f660a1afe365e436",
+                "sha256:5419a127426084933076132d317911e3c6eb77568a1ce23c3ac1e12d111e61e0",
+                "sha256:554bec92ee7d1e9d10ded2f7e92a5d70c1f74ba9524947c0ba0c850c7b011828",
+                "sha256:5e89468fbd2fcd733b5899333bc54d0d06c80e04cd23d8c6f3e0542358c6060b",
+                "sha256:65535bc550b70bd6271984d9863a37741352b4aad6fb1b3344a54e6950249b55",
+                "sha256:6ab9516b85bebe7aa83f309bacc5f44a61eeb90d0b4ec125d2d003ce41932d36",
+                "sha256:6addc3b6d593cd980989261dc1cce38263c76954d758c3c94de51f1e010c9a50",
+                "sha256:728f2694fa743a996d7784a6194da430f197d5c58e2f4e278612b359f455e4a2",
+                "sha256:785e4056b5a8b28f05a533fab69febf5004458e20dad7e2e13a3120d8ecec75a",
+                "sha256:78cf5eefac2b52c10398a42765bfa981ce2372cbc0457e6bf9658f41ec3c41d8",
+                "sha256:7f836217000342d448e1c9a342e9163149e45d5b5eca76a30e84503a5a96cab0",
+                "sha256:8d41a46251bf0634e21fac50ffd643216ccecfaf3701a063257fe0b2be1b6548",
+                "sha256:984fe150f350a3c91e84de405fe49e688aa6092b3525f407a18b9646f6612320",
+                "sha256:9b24bcff7853ed18a63cfb0c2b008936a9554af24af2fb146e16d8e1aed75748",
+                "sha256:b1b35d9d3a65542ed2e9d90115dfd16bbc027b3f07ee3304fc83580f26e43249",
+                "sha256:b1b52c9e5f8aa2b802d48bd693190341fae201ea51c7a167d69fc48b60e8a959",
+                "sha256:bbf203f1a814007ce24bd4d51362991d5cb90ba0c177a9c08825f2cc304d871f",
+                "sha256:be243c7e2bfcf6cc4cb350c0d5cdf15ca6383bbcb2a8ef51d3c9411a9d4386f0",
+                "sha256:bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd",
+                "sha256:c46837ea467ed1efea562bbeb543994c2d1f6e800785bd5a2c98bc096f5cb220",
+                "sha256:dfb4f4dd568de1b6af9f4cda334adf7d72cf5bc052516e1b2608b683375dd95c",
+                "sha256:ed7b00096790213e09eb11c97cc6e2b757f15f3d2f85833cd2d3ec3fe37c1722"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==38.0.1"
+            "version": "==38.0.3"
         },
         "docutils": {
             "hashes": [
@@ -242,11 +252,11 @@
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:2c3400c9e9c7fee46c4732fb32b933577aebb07b5e94df025f6ff1a30d2397d0",
-                "sha256:f4b779fc2a035904b97bef0542110372efd94aa7ab2c13749af73158c08be110"
+                "sha256:555170b4e13a823f4472bc12a148aef90febd5b90b16be83651d35524f34acb3",
+                "sha256:ed9c0cd58e05959a56e306ecf444f794da6afde75b213e26758f7a317e5e668c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
-            "version": "==7.17.6"
+            "version": "==7.17.7"
         },
         "elasticsearch-dsl": {
             "hashes": [
@@ -282,11 +292,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:6bd3451b8271132f099ceeaf581392eaf6c274af74bb06144307870479d0697c",
-                "sha256:77bfbd299d8709f6af7e0c70840ef26e7aff7cf0c1ed53b42dd7fc3a310fcb02"
+                "sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f",
+                "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.28"
+            "version": "==3.1.29"
         },
         "idna": {
             "hashes": [
@@ -376,11 +386,11 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:cfcc4ff8e698256fc17ea3ff796478b050852585aa5bae79ecd05b2ab7b39b9a",
-                "sha256:da3e18aac0a3c003e9eea1a81bd23e5a3a75d745670dcf736317b7d966887fdf"
+                "sha256:b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe",
+                "sha256:db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a"
             ],
             "markers": "python_version >= '2.6'",
-            "version": "==5.10.0"
+            "version": "==5.11.0"
         },
         "pycparser": {
             "hashes": [
@@ -399,11 +409,11 @@
         },
         "pyjwt": {
             "hashes": [
-                "sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80",
-                "sha256:e77ab89480905d86998442ac5788f35333fa85f65047a534adc38edf3c88fc3b"
+                "sha256:69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd",
+                "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pyparsing": {
             "hashes": [
@@ -423,10 +433,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91",
-                "sha256:48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"
+                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
+                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
             ],
-            "version": "==2022.4"
+            "version": "==2022.6"
         },
         "pyyaml": {
             "hashes": [
@@ -559,11 +569,11 @@
                 "md"
             ],
             "hashes": [
-                "sha256:d3f06a69e8c40fca9ab3174eca48f96d9771eddb43517b17d96583418427b106",
-                "sha256:e8ad25293c98f781dbc2c5a36a309929390009f902f99e1798c761aaf04a7923"
+                "sha256:cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
+                "sha256:f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==37.2"
+            "version": "==37.3"
         },
         "requests": {
             "hashes": [
@@ -598,11 +608,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:5b10cb1022dac8c035f75767799c39217a05fc0fe2d6fe5597560d38e44f0363",
-                "sha256:7abf6fabd7b58d0727b7317d5e2650ef68765bbe0ccb63c8795fa8683477eaa2"
+                "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d",
+                "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==5.2.3"
+            "version": "==5.3.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -659,13 +669,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.9.0"
-        },
-        "types-cryptography": {
-            "hashes": [
-                "sha256:913b3e66a502edbf4bfc3bb45e33ab476040c56942164a7ff37bd1f0ef8ef783",
-                "sha256:b85c45fd4d3d92e8b18e9a5ee2da84517e8fff658e3ef5755c885b1c2a27c1fe"
-            ],
-            "version": "==3.3.23"
         },
         "uritemplate": {
             "hashes": [
@@ -809,6 +812,14 @@
             ],
             "version": "==0.3.6"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
+                "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.0.4"
+        },
         "filelock": {
             "hashes": [
                 "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
@@ -851,11 +862,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:6c32dbd747aa4ceee1df33f25fed0b0f6e0d65721b15bd151307ff7056d50245",
-                "sha256:b276db7ec52d7e89f5bc4653380e33054ddc803d25875952ad90b0f012cbcdaa"
+                "sha256:906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f",
+                "sha256:a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.6"
+            "version": "==2.5.9"
         },
         "idna": {
             "hashes": [
@@ -898,11 +909,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.2"
+            "version": "==2.5.4"
         },
         "pluggy": {
             "hashes": [
@@ -919,14 +930,6 @@
             ],
             "index": "pypi",
             "version": "==2.20.0"
-        },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -962,11 +965,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
-                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
+                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
             ],
             "index": "pypi",
-            "version": "==7.1.3"
+            "version": "==7.2.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -1048,11 +1051,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
-                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
+                "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840",
+                "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.4.1"
+            "version": "==65.6.0"
         },
         "six": {
             "hashes": [
@@ -1082,7 +1085,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "urllib3": {
@@ -1095,11 +1098,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da",
-                "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"
+                "sha256:8691e3ff9387f743e00f6bb20f70121f5e4f596cae754531f2b3b3a1b1ac696e",
+                "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.16.5"
+            "version": "==20.16.7"
         }
     }
 }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,67 +5,67 @@ cfgv==3.3.1 ; python_full_version >= '3.6.1'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
 coverage[toml]==6.5.0 ; python_version >= '3.7'
 distlib==0.3.6
+exceptiongroup==1.0.4 ; python_version < '3.11'
 filelock==3.8.0 ; python_version >= '3.7'
 flake8==5.0.4
 flake8-docstrings==1.6.0
 flake8-import-order==0.18.1
 freezegun==1.2.2
-identify==2.5.6 ; python_version >= '3.7'
+identify==2.5.9 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
 iniconfig==1.1.1
 mccabe==0.7.0 ; python_version >= '3.6'
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 packaging==21.3 ; python_version >= '3.6'
-platformdirs==2.5.2 ; python_version >= '3.7'
+platformdirs==2.5.4 ; python_version >= '3.7'
 pluggy==1.0.0 ; python_version >= '3.6'
 pre-commit==2.20.0
-py==1.11.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pycodestyle==2.9.1 ; python_version >= '3.6'
 pydocstyle==6.1.1 ; python_version >= '3.6'
 pyflakes==2.5.0 ; python_version >= '3.6'
 pyparsing==3.0.9 ; python_full_version >= '3.6.8'
-pytest==7.1.3
+pytest==7.2.0
 pytest-cov==4.0.0
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyyaml==6.0 ; python_version >= '3.6'
 requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
 requests-mock==1.10.0
-setuptools==65.4.1 ; python_version >= '3.7'
+setuptools==65.6.0 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 snowballstemmer==2.2.0
 toml==0.10.2 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-tomli==2.0.1 ; python_version >= '3.7'
+tomli==2.0.1 ; python_version < '3.11'
 urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-virtualenv==20.16.5 ; python_version >= '3.6'
+virtualenv==20.16.7 ; python_version >= '3.6'
 alabaster==0.7.12
 arrow==1.2.3 ; python_version >= '3.6'
-babel==2.10.3 ; python_version >= '3.6'
+babel==2.11.0 ; python_version >= '3.6'
 bleach==5.0.1 ; python_version >= '3.7'
 cachelib==0.9.0 ; python_version >= '3.7'
 cffi==1.15.1
 click==8.1.3 ; python_version >= '3.7'
-cmarkgfm==0.8.0
-cryptography==38.0.1 ; python_version >= '3.6'
+cmarkgfm==2022.10.27
+cryptography==38.0.3 ; python_version >= '3.6'
 docutils==0.19 ; python_version >= '3.7'
-elasticsearch==7.17.6 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'
+elasticsearch==7.17.7 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'
 elasticsearch-dsl==7.4.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 flask==2.2.2 ; python_version >= '3.7'
 gitdb==4.0.9 ; python_version >= '3.6'
 github3.py==3.2.0 ; python_version >= '3.6'
-gitpython==3.1.28 ; python_version >= '3.7'
+gitpython==3.1.29 ; python_version >= '3.7'
 imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 itsdangerous==2.1.2 ; python_version >= '3.7'
 jinja2==3.1.2 ; python_version >= '3.7'
 markupsafe==2.1.1 ; python_version >= '3.7'
-pbr==5.10.0 ; python_version >= '2.6'
+pbr==5.11.0 ; python_version >= '2.6'
 pycparser==2.21
 pygments==2.13.0 ; python_version >= '3.6'
-pyjwt==2.5.0 ; python_version >= '3.7'
-pytz==2022.4
+pyjwt==2.6.0 ; python_version >= '3.7'
+pytz==2022.6
 pyzmq==24.0.1 ; python_version >= '3.6'
-readme-renderer[md]==37.2 ; python_version >= '3.7'
+readme-renderer[md]==37.3 ; python_version >= '3.7'
 smmap==5.0.0 ; python_version >= '3.6'
-sphinx==5.2.3 ; python_version >= '3.6'
+sphinx==5.3.0 ; python_version >= '3.6'
 sphinxcontrib-applehelp==1.0.2 ; python_version >= '3.5'
 sphinxcontrib-devhelp==1.0.2 ; python_version >= '3.5'
 sphinxcontrib-htmlhelp==2.0.0 ; python_version >= '3.6'
@@ -73,7 +73,6 @@ sphinxcontrib-jsmath==1.0.1 ; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3 ; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5 ; python_version >= '3.5'
 tabulate==0.9.0 ; python_version >= '3.7'
-types-cryptography==3.3.23
 uritemplate==4.1.1 ; python_version >= '3.6'
 webencodings==0.5.1
 werkzeug==2.2.2 ; python_version >= '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@ deps =
     -r{toxinidir}/test-requirements.txt
     black
 commands =
-    flake8
-    black --check --diff .
     {envpython} -m pytest \
       --cov=zubbi --cov-report=term --cov-report=html --cov-report=xml \
       --verbose {posargs}
+    flake8
+    black --check --diff .
     zubbi-scraper --help
     flask collectstatic --help
     python setup.py sdist bdist_wheel

--- a/zubbi/scraper/scraper.py
+++ b/zubbi/scraper/scraper.py
@@ -78,7 +78,15 @@ class Scraper:
         if file_infos is None:
             file_infos = {}
 
-        remote_files = self.repo.directory_contents(path)
+        try:
+            remote_files = self.repo.directory_contents(path)
+        except CheckoutError:
+            LOGGER.exception(
+                "Unable to check out repository root. The repository might be empty."
+            )
+            # As this is the initial directory, it doesn't make much sense
+            # to go any further.
+            return file_infos
 
         for file_name, remote_file in remote_files.items():
             # Skip files/directories that do not match the whitelist.


### PR DESCRIPTION
Currently, zubbi-scraper crashes when a repository is empty as we except
the root directoy to exist [1].

Theoretically, we already have tests for that in place, but the mocked
repository class also ensures that the repository root always exists.

To fix this, we catch the CheckOutError which is returned by our GitHub
connection class and adapt our test classes accordingly to cover the
case of a "missing root directory" in a repository.

[1]:

    2022-11-21T15:55:25Z DEBUG [zubbi.scraper.repos.github] Listing contents of '/' directory
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/repos/github.py", line 75, in directory_contents
        remote_directory = self._repo.directory_contents(
      File "/usr/local/lib/python3.8/dist-packages/github3/repos/repo.py", line 1488, in directory_contents
        json = self._json(self._get(url, params={"ref": ref}), 200) or []
      File "/usr/local/lib/python3.8/dist-packages/github3/models.py", line 161, in _json
        raise exceptions.error_for(response)
    github3.exceptions.NotFoundError: 404 This repository is empty.

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/local/bin/zubbi-scraper", line 8, in <module>
        sys.exit(main())
      File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 829, in __call__
        return self.main(*args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 782, in main
        rv = self.invoke(ctx)
      File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1259, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1066, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 610, in invoke
        return callback(*args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/click/decorators.py", line 21, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/main.py", line 249, in scrape
        scrape_outdated(
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/main.py", line 333, in scrape_outdated
        scrape_repo_list(
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/main.py", line 434, in scrape_repo_list
        return _scrape_repo_map(
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/main.py", line 531, in _scrape_repo_map
        scrape_repo(repo, tenants, reusable_repos, scrape_time)
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/main.py", line 559, in scrape_repo
        job_files, role_files = Scraper(repo).scrape()
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/scraper.py", line 49, in scrape
        job_files = self.scrape_job_files()
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/scraper.py", line 56, in scrape_job_files
        job_files = self.iterate_directory(
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/scraper.py", line 81, in iterate_directory
        remote_files = self.repo.directory_contents(path)
      File "/usr/local/lib/python3.8/dist-packages/zubbi/scraper/repos/github.py", line 80, in directory_contents
        raise CheckoutError(directory_path, "Directory not found.")
    zubbi.scraper.exceptions.CheckoutError: Failed to check out '/': Directory not found.