### PR TITLE
Switch to the default python dateformat for log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.8
+- Switch to default python dateformat for log messages
+
 ## 2.4.7
 
 ### Fixes

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -68,7 +68,7 @@ def configure_logger(verbosity):
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.DEBUG)
     log_formatter = logging.Formatter(
-        "%(asctime)s %(levelname)s [%(name)s] %(message)s", datefmt="%Y-%m-%dT%H:%M:%SZ"
+        "%(asctime)s %(levelname)s [%(name)s] %(message)s"
     )
     console_handler.setFormatter(log_formatter)
 


### PR DESCRIPTION
Using the default python dateformat also provides the milliseconds for
each log message and makes them look similar to other python
applications.

This also prepares the changelog for version 2.4.8.