### PR TITLE
tenant_parser.py: add support for extra-config-paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,11 @@ def repo_data():
     # and the other one is used for the parser.
     repo = DummyRepo("my/project")
 
-    tenants = {"jobs": ["foo"], "roles": ["foo", "bar"]}
+    tenants = {
+        "jobs": ["foo"],
+        "roles": ["foo", "bar"],
+        "extra_config_paths": {"zuul-extra.d": ["bar"]},
+    }
 
     job_files = {
         "zuul.d/jobs.yaml": {
@@ -89,6 +93,10 @@ def repo_data():
         },
         "zuul.d/jobs-parse-error.yaml": {
             "content": raw_file("repo_files/zuul.d/jobs-parse-error.yaml"),
+            "blame": [],
+        },
+        "zuul-extra.d/extra-jobs.yaml": {
+            "content": raw_file("repo_files/zuul-extra.d/extra-jobs.yaml"),
             "blame": [],
         },
     }

--- a/tests/scraper/test_repo_parser.py
+++ b/tests/scraper/test_repo_parser.py
@@ -30,7 +30,12 @@ def test_parse(repo_data):
     repo, tenants, job_files, role_files = repo_data
 
     jobs, roles = RepoParser(
-        repo, tenants, job_files, role_files, scrape_time, is_reusable_repo=False
+        repo,
+        tenants,
+        job_files,
+        role_files,
+        scrape_time,
+        is_reusable_repo=False,
     ).parse()
 
     # We assume that we can access the resulting jobs and roles dictionary
@@ -39,6 +44,7 @@ def test_parse(repo_data):
     job_2 = jobs[1]
     job_3 = jobs[2]
     job_4 = jobs[3]
+    job_5 = jobs[4]
     role_1 = [r for r in roles if r["role_name"] == "foo"][0]
     role_2 = [r for r in roles if r["role_name"] == "bar"][0]
 
@@ -105,6 +111,23 @@ def test_parse(repo_data):
         "reusable": False,
         "line_start": 23,
         "line_end": 25,
+        "scrape_time": scrape_time,
+        "last_updated": None,
+    }
+
+    expected_job_5 = {
+        "job_name": "awesome-job",
+        "repo": "my/project",
+        "tenants": ["bar"],
+        "description": "Job in custom directory, without a playbook or parent.\n",
+        "description_html": "<p>Job in custom directory, without a playbook or parent.</p>\n",
+        "parent": "base",
+        "url": "https://github/zuul-extra.d/extra-jobs.yaml",
+        "private": False,
+        "platforms": [],
+        "reusable": False,
+        "line_start": 1,
+        "line_end": 4,
         "scrape_time": scrape_time,
         "last_updated": None,
     }
@@ -198,6 +221,7 @@ def test_parse(repo_data):
     assert job_2.to_dict(skip_empty=False) == expected_job_2
     assert job_3.to_dict(skip_empty=False) == expected_job_3
     assert job_4.to_dict(skip_empty=False) == expected_job_4
+    assert job_5.to_dict(skip_empty=False) == expected_job_5
     assert role_1.to_dict(skip_empty=False) == expected_role_1
     assert role_2.to_dict(skip_empty=False) == expected_role_2
 
@@ -208,7 +232,12 @@ def test_parse_reusable_repo(repo_data):
     repo, tenants, job_files, role_files = repo_data
 
     jobs, roles = RepoParser(
-        repo, tenants, job_files, role_files, scrape_time, is_reusable_repo=True
+        repo,
+        tenants,
+        job_files,
+        role_files,
+        scrape_time,
+        is_reusable_repo=True,
     ).parse()
 
     # We assume that we can access the resulting jobs and roles dictionary

--- a/tests/testdata/repo_files/zuul-extra.d/extra-jobs.yaml
+++ b/tests/testdata/repo_files/zuul-extra.d/extra-jobs.yaml
@@ -1,0 +1,4 @@
+- job:
+    name: awesome-job
+    description: |
+      Job in custom directory, without a playbook or parent.

--- a/tests/testdata/test.foo.yaml
+++ b/tests/testdata/test.foo.yaml
@@ -7,9 +7,18 @@
           - orga1/repo1:
               exclude: [pipeline, project]
           - orga1/repo2
+          - orga1/repo3:
+              exclude:
+                - project
+                - pipeline
+              extra-config-paths:
+                - project-extra.yaml
+                - zuul-extra.d/
           - orga2/repo1
         untrusted-projects:
           - orga2/repo1: {shadow: orga1/repo2}
           - orga1/repo2:
               exclude: [project]
+              extra-config-paths:
+                - zuul-extra.d/
           - orga2/repo3

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -556,14 +556,22 @@ def _scrape_repo_map(
 
 
 def scrape_repo(repo, tenants, reusable_repos, scrape_time):
-    job_files, role_files = Scraper(repo).scrape()
+    job_files, role_files = Scraper(
+        repo,
+        tenants.get("extra-config-paths", {}),
+    ).scrape()
 
-    is_rusable_repo = repo.repo_name in reusable_repos
+    is_reusable_repo = repo.repo_name in reusable_repos
     jobs = []
     roles = []
     try:
         jobs, roles = RepoParser(
-            repo, tenants, job_files, role_files, scrape_time, is_rusable_repo
+            repo,
+            tenants,
+            job_files,
+            role_files,
+            scrape_time,
+            is_reusable_repo,
         ).parse()
     except Exception:
         LOGGER.exception("Unable to parse job or role definitions in repo '%s'", repo)

--- a/zubbi/scraper/repo_parser.py
+++ b/zubbi/scraper/repo_parser.py
@@ -31,7 +31,13 @@ LOGGER = logging.getLogger(__name__)
 
 class RepoParser:
     def __init__(
-        self, repo, tenants, job_files, role_files, scrape_time, is_reusable_repo
+        self,
+        repo,
+        tenants,
+        job_files,
+        role_files,
+        scrape_time,
+        is_reusable_repo,
     ):
         self.repo = repo
         self.tenants = tenants
@@ -64,6 +70,15 @@ class RepoParser:
             # LOGGER.debug(json.dumps(repo_jobs, indent=4))
         return repo_jobs
 
+    def _get_job_tenants(self, file_path):
+        extra_config_paths = self.tenants.get("extra_config_paths", {})
+        tenants = self.tenants["jobs"]
+        for extra_config_path in extra_config_paths.keys():
+            if file_path.startswith(extra_config_path):
+                tenants = extra_config_paths[extra_config_path]
+                break
+        return tenants
+
     def parse_job_definitions(self, file_path, job_info):
         try:
             jobs_yaml = yaml.load(job_info["content"], Loader=ZuulSafeLoader)
@@ -83,7 +98,7 @@ class RepoParser:
                 job = ZuulJob(meta={"id": uuid})
                 job.job_name = job_name
                 job.repo = self.repo.name
-                job.tenants = self.tenants["jobs"]
+                job.tenants = self._get_job_tenants(file_path)
                 job.private = self.repo.private
                 job.scrape_time = self.scrape_time
                 job.line_start = job_def["__line_start__"]

--- a/zubbi/scraper/scraper.py
+++ b/zubbi/scraper/scraper.py
@@ -33,8 +33,11 @@ REPO_ROOT = "/"
 
 
 class Scraper:
-    def __init__(self, repo):
+    def __init__(self, repo, extra_config_paths=None):
         self.repo = repo
+        self.extra_config_paths = (
+            list(extra_config_paths.keys()) if extra_config_paths else []
+        )
 
     def scrape(self):
         LOGGER.info("Scraping '%s'", self.repo.name)
@@ -55,7 +58,7 @@ class Scraper:
 
         job_files = self.iterate_directory(
             REPO_ROOT,
-            whitelist=ZUUL_DIRECTORIES + ZUUL_FILES,
+            whitelist=ZUUL_DIRECTORIES + ZUUL_FILES + self.extra_config_paths,
             # NOTE (felix): As we provide this directly to the
             # str.endswith() method, the argument must be a str or a
             # tuple of strings, otherwise the following exception is


### PR DESCRIPTION
When creating/updating repo_map, 'extra-config-paths' list is extracted from tenant configuration and saved in repo's 'tenants' dictionary (next to 'jobs' and 'roles')

Extra-config-paths values are used for Scraper class initialization. The 'scrape_job_files' method extends the whitelist with it

'test_integration' tests were extended to verify this new functionality