### PR TITLE
Fix creation of repo map in TenantParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.6.1
+
+### Fixes
+- Fixed a bug in the tenant parser that made zubbi-scraper crash when a tenant
+  config file contained a special project format.
+
+## 2.6.0
+
+### New Features
+- Zubbi now parses job definitions provided via `extra-config-paths`
+  configuration files.
+
 ## 2.5.0
 
 ### New Features

--- a/tests/scraper/test_tenant_parser.py
+++ b/tests/scraper/test_tenant_parser.py
@@ -1,0 +1,59 @@
+# Copyright 2024 BMW Car IT GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from zubbi.scraper.tenant_parser import TenantParser
+
+
+def test_parse():
+    expected_repo_map = {
+        "orga1/repo1": {
+            "tenants": {
+                "jobs": ["bar"],
+                "roles": ["foo", "bar"],
+                "extra_config_paths": {"zuul-extra.d": ["foo"]},
+            },
+            "connection_name": "github",
+        },
+        "orga1/repo2": {
+            "tenants": {"jobs": ["foo"], "roles": ["foo"]},
+            "connection_name": "github",
+        },
+        "orga1/repo3": {
+            "tenants": {"jobs": ["foo"], "roles": ["foo"]},
+            "connection_name": "github",
+        },
+        "orga1/repo4": {
+            "tenants": {"jobs": ["foo"], "roles": ["foo"]},
+            "connection_name": "github",
+        },
+        "orga2/repo1": {
+            "tenants": {"jobs": ["foo", "bar"], "roles": ["foo", "bar"]},
+            "connection_name": "github",
+        },
+        "orga2/repo2": {
+            "tenants": {"jobs": ["foo"], "roles": ["foo", "bar"]},
+            "connection_name": "github",
+        },
+        "orga2/repo3": {
+            "tenants": {"jobs": ["foo"], "roles": ["foo"]},
+            "connection_name": "github",
+        },
+    }
+
+    tenant_parser = TenantParser(
+        sources_file="tests/testdata/tenant_configs/tenant-config.yaml"
+    )
+    tenant_parser.parse()
+
+    assert tenant_parser.repo_map == expected_repo_map

--- a/tests/testdata/tenant_configs/tenant-config.yaml
+++ b/tests/testdata/tenant_configs/tenant-config.yaml
@@ -1,0 +1,62 @@
+- tenant:
+    name: foo
+    source:
+      github:
+        config-projects:
+          - orga1/repo1:
+              extra-config-paths:
+                - zuul-extra.d/
+              exclude:
+                - project
+                - pipeline
+                - job
+
+          - orga1/repo2:
+              exclude: project
+
+          - orga1/repo3
+
+          - orga1/repo4:
+              include:
+                - job
+                - secret
+
+        untrusted-projects:
+          - orga2/repo1:
+              include: []
+
+          - orga2/repo2:
+              shadow: orga1/repo1
+              exclude: project
+
+          - orga2/repo3
+
+          # This format is currently not supported but Zubbi and will be
+          # ignored.
+          - include: []
+            projects:
+              - orga3/repo1
+              - orga3/repo2
+
+          # This format is currently not supported but Zubbi and will be
+          # ignored.
+          - exclude:
+              - job
+              - secret
+            projects:
+              - orga3/repo3
+              - orga3/repo4
+
+- tenant:
+    name: bar
+    source:
+      github:
+        config-projects:
+          - orga1/repo1
+          - orga2/repo1:
+              include:
+                - job
+        untrusted-projects:
+          - orga2/repo2:
+              exclude:
+                - job


### PR DESCRIPTION
The latest change introduced a bug that failed to parse the following
configuration snippets [1] in a tenant-config.yaml file.

This kind of configuration wasn't supported by Zubbi before, but also
didn't fail when parsing the tenant configuration file. For now,
explicitly ignore this kind of configuration.

Additionally, we also add an explicit test for the tenant parser with
a variety of project configs to catch those errors more easily.

This change also fixes the exclusion of jobs from a project, which
didn't work properly due to the usage of "jobs" instead of "job".

[1]:

      # Include nothing from projects foo, bar
      - include: []
        projects:
          - foo
          - bar

      # Exclude jobs and semaphores from foo
      - exclude:
          - job
          - semaphore
        projects:
          - foo