### PR TITLE
Fix typo in extra_config_paths variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.2
+
+### Fixes
+- Fixed a bug in the tenant parser preventing the `extra-config-paths` feature
+  to work correctly.
+
 ## 2.6.1
 
 ### Fixes

--- a/zubbi/scraper/main.py
+++ b/zubbi/scraper/main.py
@@ -558,7 +558,7 @@ def _scrape_repo_map(
 def scrape_repo(repo, tenants, reusable_repos, scrape_time):
     job_files, role_files = Scraper(
         repo,
-        tenants.get("extra-config-paths", {}),
+        tenants.get("extra_config_paths", {}),
     ).scrape()
 
     is_reusable_repo = repo.repo_name in reusable_repos


### PR DESCRIPTION
This prevents the `extra-config-paths` feature to work correctly.