### PR TITLE
scrape_role_files: add support for nested role directories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,14 @@ def repo_data():
             },
             "changelog_file": None,
         },
+        "foobar/baz": {
+            "last_changed": "2018-09-17 15:15:15",
+            "readme_file": {
+                "path": "roles/foobar/baz/README.rst",
+                "content": raw_file("repo_files/roles/foobar/baz/README.rst"),
+            },
+            "changelog_file": None,
+        },
     }
 
     return repo, tenants, job_files, role_files

--- a/tests/scraper/test_integration.py
+++ b/tests/scraper/test_integration.py
@@ -73,6 +73,7 @@ class MockContents:
     DIR = "dir"
 
     def __init__(self, path, type):
+        self.name = path.split("/")[-1]
         self.path = path
         self.type = type
 
@@ -101,9 +102,10 @@ class MockGitHubRepository(GitHubRepository):
             "zuul.d/jobs.yaml": MOCKED_JOB_CONTENT,
             "roles": {"docker-run": MockContents("roles/docker-run", MockContents.DIR)},
             "roles/docker-run": {
+                "tasks": MockContents("roles/docker-run/tasks", MockContents.DIR),
                 "README.rst": MockContents(
                     "roles/docker-run/README.rst", MockContents.FILE
-                )
+                ),
             },
             "roles/docker-run/README.rst": MOCKED_ROLE_DESCRIPTION,
             "roles/ignored": MockContents("not a valid role", MockContents.FILE),
@@ -117,25 +119,40 @@ class MockGitHubRepository(GitHubRepository):
                 "bar": MockContents("roles/bar", MockContents.DIR),
                 "foobar": MockContents("roles/foobar", MockContents.DIR),
                 "empty-dir": MockContents("roles/empty-dir", MockContents.DIR),
+                "foobaz": MockContents("roles/foobaz", MockContents.DIR),
             },
             "roles/foo": {
-                "README.md": MockContents("roles/foo/README.md", MockContents.FILE)
+                "defaults": MockContents("roles/foo/defaults", MockContents.DIR),
+                "README.md": MockContents("roles/foo/README.md", MockContents.FILE),
             },
             "roles/bar": {
-                "README.txt": MockContents("roles/bar/README.txt", MockContents.FILE)
+                "library": MockContents("roles/bar/library", MockContents.DIR),
+                "README.txt": MockContents("roles/bar/README.txt", MockContents.FILE),
             },
             "roles/foobar": {
-                "README": MockContents("roles/foobar/README", MockContents.FILE)
+                "handlers": MockContents("roles/foobar/handlers", MockContents.DIR),
+                "README": MockContents("roles/foobar/README", MockContents.FILE),
             },
             "roles/empty-dir": {
+                "meta": MockContents("roles/empty-dir/meta", MockContents.DIR),
                 "README.whatever": MockContents(
                     "roles/empty-dir/README.whatever", MockContents.FILE
-                )
+                ),
+            },
+            "roles/foobaz": {
+                "baz": MockContents("roles/foobaz/baz", MockContents.DIR),
+            },
+            "roles/foobaz/baz": {
+                "vars": MockContents("roles/foobaz/baz/vars", MockContents.DIR),
+                "README.rst": MockContents(
+                    "roles/foobaz/baz/README.rst", MockContents.FILE
+                ),
             },
             "roles/foo/README.md": "# Just some Markdown",
             "roles/bar/README.txt": "Just some simple text\nwith a line break",
             "roles/foobar/README": "Simple text in a file without extension",
-            "roles/empty-dir/REAMDE.whatever": "This file won't be checked out",
+            "roles/empty-dir/README.whatever": "This file won't be checked out",
+            "roles/foobaz/baz/README.rst": "Simple readme file from nested role",
         },
         "orga1/repo3": {
             REPO_ROOT: {
@@ -215,19 +232,24 @@ def test_scrape():
         "orga1/repo2": (
             {},
             {
-                "foo": {
-                    "last_changed": "2018-09-17 15:15:15",
-                    "readme_file": {
-                        "path": "roles/foo/README.md",
-                        "content": "# Just some Markdown",
-                    },
-                    "changelog_file": None,
-                },
                 "bar": {
                     "last_changed": "2018-09-17 15:15:15",
                     "readme_file": {
                         "path": "roles/bar/README.txt",
                         "content": "Just some simple text\nwith a line break",
+                    },
+                    "changelog_file": None,
+                },
+                "empty-dir": {
+                    "last_changed": "2018-09-17 15:15:15",
+                    "readme_file": None,
+                    "changelog_file": None,
+                },
+                "foo": {
+                    "last_changed": "2018-09-17 15:15:15",
+                    "readme_file": {
+                        "path": "roles/foo/README.md",
+                        "content": "# Just some Markdown",
                     },
                     "changelog_file": None,
                 },
@@ -239,9 +261,12 @@ def test_scrape():
                     },
                     "changelog_file": None,
                 },
-                "empty-dir": {
+                "foobaz/baz": {
                     "last_changed": "2018-09-17 15:15:15",
-                    "readme_file": None,
+                    "readme_file": {
+                        "path": "roles/foobaz/baz/README.rst",
+                        "content": "Simple readme file from nested role",
+                    },
                     "changelog_file": None,
                 },
             },

--- a/tests/scraper/test_repo_parser.py
+++ b/tests/scraper/test_repo_parser.py
@@ -47,6 +47,7 @@ def test_parse(repo_data):
     job_5 = jobs[4]
     role_1 = [r for r in roles if r["role_name"] == "foo"][0]
     role_2 = [r for r in roles if r["role_name"] == "bar"][0]
+    role_3 = [r for r in roles if r["role_name"] == "foobar/baz"][0]
 
     expected_job_1 = {
         "job_name": "my-cool-new-job",
@@ -215,6 +216,39 @@ def test_parse(repo_data):
         "last_updated": "2018-09-17 15:15:15",
     }
 
+    expected_role_3 = {
+        "role_name": "foobar/baz",
+        "repo": "my/project",
+        "tenants": ["foo", "bar"],
+        "description": (
+            "Yet another simple description\n\n"
+            "**Role variables**\n\n"
+            ".. zuul:rolevar:: my_mandatory_variable\n\n"
+            "   This variable is mandatory.\n"
+        ),
+        "description_html": (
+            "<p>Yet another simple description</p>\n"
+            "<p><strong>Role variables</strong></p>\n"
+            '<dl class="zuul rolevar">\n'
+            '<dt class="sig sig-object zuul" id="rolevar-my_mandatory_variable">\n'
+            '<span class="sig-name descname">'
+            '<span class="pre">my_mandatory_variable</span>'
+            "</span>"
+            '<a class="headerlink" href="#rolevar-my_mandatory_variable" '
+            'title="Link to this definition">'
+            "¶</a><br /></dt>\n"
+            "<dd><p>This variable is mandatory.</p>\n"
+            "</dd></dl>\n"
+            "\n"
+        ),
+        "url": "https://github/my/project/tree/master/roles/foobar/baz",
+        "private": False,
+        "platforms": [],
+        "reusable": False,
+        "scrape_time": scrape_time,
+        "last_updated": "2018-09-17 15:15:15",
+    }
+
     # NOTE (fschmidt): Without the skip_empty flag, empty (= None) keys will
     # be stripped from the resulting dict.
     assert job_1.to_dict(skip_empty=False) == expected_job_1
@@ -224,6 +258,7 @@ def test_parse(repo_data):
     assert job_5.to_dict(skip_empty=False) == expected_job_5
     assert role_1.to_dict(skip_empty=False) == expected_role_1
     assert role_2.to_dict(skip_empty=False) == expected_role_2
+    assert role_3.to_dict(skip_empty=False) == expected_role_3
 
 
 def test_parse_reusable_repo(repo_data):

--- a/tests/testdata/repo_files/roles/foobar/baz/README.rst
+++ b/tests/testdata/repo_files/roles/foobar/baz/README.rst
@@ -1,0 +1,7 @@
+Yet another simple description
+
+**Role variables**
+
+.. zuul:rolevar:: my_mandatory_variable
+
+   This variable is mandatory.


### PR DESCRIPTION
Changing the way how roles are scraped. Previously directories present in default roles directory were treated as roles (dir name is role name).

Now scraper enters each directory looking for one of 8 specified subdirs. When at least one such subdir is found, its parent is treated as role, else subdir is added to search list (this is equivalent of traversing repository)

Adjusting tests to utilize nested role directories