### PR TITLE
Make zubbi-web work with path-like role names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.0
+
+### New Features
+- Zubbi now searches the `roles` directory recursively for roles defined in a
+  subdirectory.
+
 ## 2.6.2
 
 ### Fixes

--- a/zubbi/models.py
+++ b/zubbi/models.py
@@ -15,6 +15,7 @@
 import collections
 import logging
 import ssl
+from urllib.parse import quote_plus
 
 import markupsafe
 from elasticsearch.exceptions import ElasticsearchException
@@ -270,8 +271,9 @@ class BlockSearch(Search):
 
     def detail_query(self, block_name, repo, extra_filter=None):
         extra_filter = extra_filter or []
+        query_string = block_name.translate(TRANSLATION_TABLE)
         detail_query = [
-            Q("query_string", query=block_name, fields=["job_name", "role_name"]),
+            Q("query_string", query=query_string, fields=["job_name", "role_name"]),
             Q("match", repo=repo),
         ]
         return self.query("bool", filter=extra_filter, must=detail_query)
@@ -336,6 +338,9 @@ def init_elasticsearch(app):
     app.add_template_test(role_type)
     app.add_template_test(job_type)
     app.add_template_filter(block_type)
+    # Jinja2 doesn't provide it's own filter equivalent for
+    # urllib.parse.quote_plus, so we add it by ourselves.
+    app.add_template_filter(quote_plus)
 
 
 def init_elasticsearch_con(

--- a/zubbi/templates/search.html
+++ b/zubbi/templates/search.html
@@ -93,7 +93,7 @@ Search {%- if result is not none %} results for "{{ query }}"{%- endif %}
         </h5>
         <h6 class="card-subtitle mb-2 text-muted">{{ match.repo }}</h6>
         <p class="card-text">{% if match.description_rendered %}{{ match.description_rendered.split('\n')|first|striptags }}{% endif %}</p>
-        <a href="{{ url_for('zubbi.details', repo=match.repo, block_type=match|block_type, name=match.name) }}" class="btn btn-primary"><i class="fas fa-info-circle"></i> Show details</a>
+        <a href="{{ url_for('zubbi.details', repo=match.repo, block_type=match|block_type, name=match.name|quote_plus) }}" class="btn btn-primary"><i class="fas fa-info-circle"></i> Show details</a>
       </div>
     </div>
   {%- endfor %}

--- a/zubbi/views.py
+++ b/zubbi/views.py
@@ -17,6 +17,7 @@ import hashlib
 import hmac
 import json
 import math
+import urllib.parse
 
 from elasticsearch_dsl import Q
 from flask import (
@@ -159,7 +160,7 @@ class SearchView(ZubbiMethodView):
                     "zubbi.details",
                     repo=block.repo,
                     block_type=block_type(block),
-                    name=block.name,
+                    name=urllib.parse.quote_plus(block.name),
                 ),
                 code=303,
             )
@@ -199,6 +200,7 @@ class DetailView(ZubbiMethodView):
             abort(400, "Unknown block type '{}'".format(block_type))
 
         extra_filter = Q("term", private=False)
+        name = urllib.parse.unquote_plus(name)
         search = BlockSearch(block_class=BlockClass).detail_query(
             name, repo, extra_filter
         )


### PR DESCRIPTION
Zubbi-scraper is now able to parse roles that are defined in a nested 
directory structure. Those roles have a path-like name, e.g. foo/bar.

In order to show those roles properly in zubbi-web, we have to urlencode 
the role names in the URL for the details view and also escape the special
characters ("/") in the Elasticsearch query string. The latter one was
already done in other places, so this just aligns the details query with
the "normal" search query.