### PR TITLE
fix: Use Ruff rules config instead of double Ruff checks in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,6 @@ repos:
   hooks:
     # Run the linter
     - id: ruff-check
-    # Sort import statements
-    - id: ruff-check
-      args: ["--select", "I", "--fix"]
+      args: [ --fix ]
     # Run the formatter
     - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,7 @@ packages = ["zubbi"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=zubbi --cov-report=term --cov-report=html --cov-report=xml --verbose"
+
+[tool.ruff]
+line-length = 88
+lint.select = ["E4", "E7", "E9", "F", "I"]


### PR DESCRIPTION
## Description

Currently, `ruff check` runs multiple times in pre-commit.  
This PR moves the Ruff rule configuration from `.pre-commit-config.yaml` into `pyproject.toml`, using the default rules (`E4`, `E7`, `E9`, `F`) plus the additional `I` import-sort rules that were previously specified explicitly in `.pre-commit-config.yaml`.

**Reference:**  
Ruff default rules - https://docs.astral.sh/ruff/settings/#lint_select