### PR TITLE
Build dist without sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ update:
 	uv lock --upgrade
 
 dist:
-	uv build
+	uv build --no-sources
 
 # Commands without file dependencies
 .PHONY: help lint test dist


### PR DESCRIPTION
This is recommended by uv as stated in the [documentation](https://docs.astral.sh/uv/guides/package/#building-your-package):

> By default, `uv build` respects `tool.uv.sources` when resolving build
> dependencies from the `build-system.requires` section of the
> `pyproject.toml`. When publishing a package, we recommend running
> `uv build --no-sources` to ensure that the package builds correctly
> when `tool.uv.sources` is disabled, as is the case when using other
> build tools, like pypa/build.